### PR TITLE
chore: Add dependency to LatencyUtils as it's required by micrometer

### DIFF
--- a/gravitee-node-vertx/pom.xml
+++ b/gravitee-node-vertx/pom.xml
@@ -55,6 +55,12 @@
             <version>${micrometer-registry-prometheus.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.latencyutils</groupId>
+            <artifactId>LatencyUtils</artifactId>
+            <version>${LatencyUtils.version}</version>
+        </dependency>
+
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,10 @@
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <hazelcast.version>4.1.1</hazelcast.version>
+
+        <!-- WARNING: the next two dependencies versions must be kept in sync regarding vertx-micrometer-metrics -->
         <micrometer-registry-prometheus.version>1.6.2</micrometer-registry-prometheus.version>
+        <LatencyUtils.version>2.0.3</LatencyUtils.version>
     </properties>
     <build>
       <plugins>


### PR DESCRIPTION
Closes gravitee-io/issues#5996