### PR TITLE
fix: ServiceManager takes care of AbstractService.getOrder() to start services

### DIFF
--- a/gravitee-node-plugins/gravitee-node-plugins-service/src/main/java/io/gravitee/node/plugins/service/impl/ServiceManagerImpl.java
+++ b/gravitee-node-plugins/gravitee-node-plugins-service/src/main/java/io/gravitee/node/plugins/service/impl/ServiceManagerImpl.java
@@ -23,6 +23,10 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.reverseOrder;
+import static java.util.stream.Collectors.toList;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
@@ -42,21 +46,23 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
     protected void doStart() throws Exception {
         super.doStart();
 
-        for (AbstractService service : services) {
+        List<AbstractService> orderedServices = services.stream().sorted(comparing(AbstractService::getOrder)).collect(toList());
+
+        for (AbstractService service : orderedServices) {
             try {
                 service.preStart();
             } catch (Exception ex) {
                 LOGGER.error("Unexpected error while pre-starting service", ex);
             }
         }
-        for (AbstractService service : services) {
+        for (AbstractService service : orderedServices) {
             try {
                 service.start();
             } catch (Exception ex) {
                 LOGGER.error("Unexpected error while starting service", ex);
             }
         }
-        for (AbstractService service : services) {
+        for (AbstractService service : orderedServices) {
             try {
                 service.postStart();
             } catch (Exception ex) {
@@ -69,21 +75,23 @@ public class ServiceManagerImpl extends AbstractService implements ServiceManage
     protected void doStop() throws Exception {
         super.doStop();
 
-        for (AbstractService service : services) {
+        List<AbstractService> orderedServices = services.stream().sorted(comparing(AbstractService::getOrder, reverseOrder())).collect(toList());
+
+        for (AbstractService service : orderedServices) {
             try {
                 service.preStop();
             } catch (Exception ex) {
                 LOGGER.error("Unexpected error while pre-stopping service", ex);
             }
         }
-        for (AbstractService service : services) {
+        for (AbstractService service : orderedServices) {
             try {
                 service.stop();
             } catch (Exception ex) {
                 LOGGER.error("Unexpected error while stopping service", ex);
             }
         }
-        for (AbstractService service : services) {
+        for (AbstractService service : orderedServices) {
             try {
                 service.postStop();
             } catch (Exception ex) {

--- a/gravitee-node-plugins/gravitee-node-plugins-service/src/test/java/io/gravitee/node/plugins/service/impl/ServiceManagerImplTest.java
+++ b/gravitee-node-plugins/gravitee-node-plugins-service/src/test/java/io/gravitee/node/plugins/service/impl/ServiceManagerImplTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugins.service.impl;
+
+import io.gravitee.common.service.AbstractService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceManagerImplTest {
+
+    private final ServiceManagerImpl serviceManager = new ServiceManagerImpl();
+
+    @Mock
+    private AbstractService<?> service1, service2, service3, service4;
+
+    @Before
+    public void setup() {
+        doReturn(700).when(service1).getOrder();
+        doReturn(900).when(service2).getOrder();
+        doReturn(750).when(service3).getOrder();
+        doReturn(699).when(service4).getOrder();
+
+        serviceManager.register(service1);
+        serviceManager.register(service2);
+        serviceManager.register(service3);
+        serviceManager.register(service4);
+
+    }
+
+    @Test
+    public void doStart_should_prestart_start_and_poststart_in_order() throws Exception {
+        serviceManager.doStart();
+
+        InOrder inOrder = inOrder(service4, service1, service3, service2);
+
+        inOrder.verify(service4, times(1)).preStart();
+        inOrder.verify(service1, times(1)).preStart();
+        inOrder.verify(service3, times(1)).preStart();
+        inOrder.verify(service2, times(1)).preStart();
+
+        inOrder.verify(service4, times(1)).start();
+        inOrder.verify(service1, times(1)).start();
+        inOrder.verify(service3, times(1)).start();
+        inOrder.verify(service2, times(1)).start();
+
+        inOrder.verify(service4, times(1)).postStart();
+        inOrder.verify(service1, times(1)).postStart();
+        inOrder.verify(service3, times(1)).postStart();
+        inOrder.verify(service2, times(1)).postStart();
+    }
+
+    @Test
+    public void doStop_should_prestop_stop_and_poststop_in_reverse_order() throws Exception {
+        serviceManager.doStop();
+
+        InOrder inOrder = inOrder(service4, service1, service3, service2);
+
+        inOrder.verify(service2, times(1)).preStop();
+        inOrder.verify(service3, times(1)).preStop();
+        inOrder.verify(service1, times(1)).preStop();
+        inOrder.verify(service4, times(1)).preStop();
+
+        inOrder.verify(service2, times(1)).stop();
+        inOrder.verify(service3, times(1)).stop();
+        inOrder.verify(service1, times(1)).stop();
+        inOrder.verify(service4, times(1)).stop();
+
+        inOrder.verify(service2, times(1)).postStop();
+        inOrder.verify(service3, times(1)).postStop();
+        inOrder.verify(service1, times(1)).postStop();
+        inOrder.verify(service4, times(1)).postStop();
+    }
+}

--- a/gravitee-node-plugins/pom.xml
+++ b/gravitee-node-plugins/pom.xml
@@ -60,5 +60,16 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Unit Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
 
     <properties>
         <gravitee-bom.version>1.3</gravitee-bom.version>
-        <gravitee-common.version>1.20.3</gravitee-common.version>
+        <gravitee-common.version>1.20.4-SNAPSHOT</gravitee-common.version>
         <gravitee-plugin.version>1.17.1</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.17.1</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6306

fix: ServiceManager takes care of AbstractService.getOrder() to start services

ServiceManager starts all services plugins using this order, starting with lower ones at first.
And stops them starting with higher ones at first.

It avoids that services consuming SyncService DEPLOY events starts after it.

