### PR TITLE
feat: make gravitee propertysource enumerable

### DIFF
--- a/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/env/AbstractGraviteePropertySource.java
+++ b/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/env/AbstractGraviteePropertySource.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.util.Assert;
 
@@ -30,7 +31,7 @@ import org.springframework.util.Assert;
  * @author GraviteeSource Team
  */
 public abstract class AbstractGraviteePropertySource
-  extends PropertySource<Map<String, Object>> {
+  extends EnumerablePropertySource<Map<String, Object>> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(
     AbstractGraviteePropertySource.class
@@ -45,6 +46,11 @@ public abstract class AbstractGraviteePropertySource
     super(name, source);
     this.propertyResolverLoader =
       applicationContext.getBean(PropertyResolverFactoriesLoader.class);
+  }
+
+  @Override
+  public String[] getPropertyNames() {
+    return source.keySet().toArray(new String[0]);
   }
 
   @Override


### PR DESCRIPTION
In gravitee-common's EnvironmentUtils class, we have a getAllProperties that should return all properties of an environment.
Because Gravitee's property source was not enumerable nor composite, the helper function was not returning gravitee properties.
See https://github.com/gravitee-io/gravitee-common/blob/master/src/main/java/io/gravitee/common/util/EnvironmentUtils.java#L69

It will fix the [Cockpit initial plans](https://github.com/gravitee-io/gravitee-cockpit/blob/master/gravitee-cockpit-service/src/main/java/com/graviteesource/cockpit/service/spring/InitialPlansConfiguration.java#L21) loading where getting all environment properties were not returning properties from gravitee source and we will be able to update `gravitee-node` dependency: https://github.com/gravitee-io/gravitee-cockpit/pull/1452

This fix is to patch the master branch.

