### PR TITLE
Avoid logging errors when Kubernetes client is not needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <gravitee-bom.version>1.3</gravitee-bom.version>
         <gravitee-common.version>1.23.0</gravitee-common.version>
         <gravitee-plugin.version>1.17.1</gravitee-plugin.version>
-        <gravitee-k8s-client.version>0.2.0</gravitee-k8s-client.version>
+        <gravitee-k8s-client.version>0.3.0-SNAPSHOT</gravitee-k8s-client.version>
         <gravitee-reporter-api.version>1.17.1</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <snakeyaml.version>1.26</snakeyaml.version>


### PR DESCRIPTION
Relying on https://github.com/gravitee-io/gravitee-kubernetes/pull/16