### PR TITLE
feat: Use the new Kubernetes Client API

### DIFF
--- a/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/AbstractKubernetesKeyStoreLoader.java
+++ b/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/AbstractKubernetesKeyStoreLoader.java
@@ -17,20 +17,20 @@ package io.gravitee.node.kubernetes.keystoreloader;
 
 import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.kubernetes.client.KubernetesClient;
-import io.gravitee.kubernetes.client.KubernetesClientV1Impl;
-import io.gravitee.kubernetes.client.KubernetesClientV1Impl.KubernetesResource;
+import io.gravitee.kubernetes.client.api.ResourceQuery;
 import io.gravitee.node.api.certificate.KeyStoreBundle;
 import io.gravitee.node.api.certificate.KeyStoreLoader;
 import io.gravitee.node.api.certificate.KeyStoreLoaderOptions;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
-import io.reactivex.Single;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import java.security.KeyStore;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,14 +42,13 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractKubernetesKeyStoreLoader<T> implements KeyStoreLoader {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractKubernetesKeyStoreLoader.class);
-    private static final int WATCH_RETRY_DELAY = 000;
     protected static final int RETRY_DELAY_MILLIS = 10000;
 
     protected final KeyStoreLoaderOptions options;
     protected final KubernetesClient kubernetesClient;
     protected final List<Consumer<KeyStoreBundle>> listeners;
     protected final Map<String, KeyStore> keyStoresByLocation;
-    protected final Map<String, KubernetesResource> resources = new HashMap<>();
+    protected final Map<String, ResourceQuery<T>> resources = new HashMap<>();
     protected KeyStoreBundle keyStoreBundle;
 
     private Disposable disposable;

--- a/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesConfigMapKeyStoreLoader.java
+++ b/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesConfigMapKeyStoreLoader.java
@@ -17,17 +17,20 @@ package io.gravitee.node.kubernetes.keystoreloader;
 
 import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.kubernetes.client.KubernetesClient;
-import io.gravitee.kubernetes.client.KubernetesClientV1Impl.KubernetesResource;
+import io.gravitee.kubernetes.client.api.ResourceQuery;
+import io.gravitee.kubernetes.client.api.WatchQuery;
 import io.gravitee.kubernetes.client.model.v1.ConfigMap;
-import io.gravitee.kubernetes.client.model.v1.ConfigMapEvent;
+import io.gravitee.kubernetes.client.model.v1.Event;
 import io.gravitee.node.api.certificate.KeyStoreLoader;
 import io.gravitee.node.api.certificate.KeyStoreLoaderOptions;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.schedulers.Schedulers;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,7 +59,7 @@ public class KubernetesConfigMapKeyStoreLoader extends AbstractKubernetesKeyStor
             .forEach(location -> {
                 final Matcher matcher = CONFIGMAP_PATTERN.matcher(location);
                 if (matcher.matches()) {
-                    this.resources.put(matcher.group(1), new KubernetesResource(location));
+                    this.resources.put(matcher.group(1), ResourceQuery.<ConfigMap>from(location).build());
                 } else {
                     throw new IllegalArgumentException(
                         "You must specify a data when using configmap (ex: /my-namespace/configmaps/my-configmap/my-keystore)."
@@ -82,7 +85,10 @@ public class KubernetesConfigMapKeyStoreLoader extends AbstractKubernetesKeyStor
             .keySet()
             .stream()
             .map(location ->
-                kubernetesClient.get(location, ConfigMap.class).observeOn(Schedulers.computation()).flatMapCompletable(this::loadKeyStore)
+                kubernetesClient
+                    .get(ResourceQuery.<ConfigMap>from(location).build())
+                    .observeOn(Schedulers.computation())
+                    .flatMapCompletable(this::loadKeyStore)
             )
             .collect(Collectors.toList());
 
@@ -94,34 +100,34 @@ public class KubernetesConfigMapKeyStoreLoader extends AbstractKubernetesKeyStor
 
     @Override
     protected Flowable<ConfigMap> watch() {
-        final List<Flowable<ConfigMapEvent>> toWatch = resources
+        final List<Flowable<Event<ConfigMap>>> toWatch = resources
             .keySet()
             .stream()
             .map(location ->
                 kubernetesClient
-                    .watch(location, ConfigMapEvent.class)
+                    .watch(WatchQuery.<ConfigMap>from(location).build())
                     .observeOn(Schedulers.computation())
                     .repeat()
                     .retryWhen(errors -> errors.delay(RETRY_DELAY_MILLIS, TimeUnit.MILLISECONDS))
             )
             .collect(Collectors.toList());
 
-        return Flowable.merge(toWatch).filter(event -> event.getType().equalsIgnoreCase("MODIFIED")).map(ConfigMapEvent::getObject);
+        return Flowable.merge(toWatch).filter(event -> event.getType().equalsIgnoreCase("MODIFIED")).map(Event::getObject);
     }
 
     @Override
     protected Completable loadKeyStore(ConfigMap configMap) {
-        final Optional<KubernetesResource> optResource = resources
+        final Optional<ResourceQuery<ConfigMap>> optResource = resources
             .values()
             .stream()
             .filter(r ->
                 r.getNamespace().equalsIgnoreCase(configMap.getMetadata().getNamespace()) &&
-                r.getName().equalsIgnoreCase(configMap.getMetadata().getName())
+                r.getResource().equalsIgnoreCase(configMap.getMetadata().getName())
             )
             .findFirst();
 
         if (optResource.isEmpty()) {
-            return Completable.error(new IllegalArgumentException("Unable to load keystore: unknown secret."));
+            return Completable.error(new IllegalArgumentException("Unable to load keystore: unknown configmap."));
         }
 
         Map<String, String> data = configMap.getBinaryData() == null ? configMap.getData() : configMap.getBinaryData();
@@ -132,7 +138,7 @@ public class KubernetesConfigMapKeyStoreLoader extends AbstractKubernetesKeyStor
             data = configMap.getData();
         }
 
-        final String dataKey = optResource.get().getKey();
+        final String dataKey = optResource.get().getResourceKey();
         if (data == null || data.get(dataKey) == null) {
             return Completable.error(
                 new IllegalArgumentException(String.format("No data has been found in the configmap for the specified key [%s].", dataKey))

--- a/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesKeyStoreLoaderFactory.java
+++ b/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesKeyStoreLoaderFactory.java
@@ -19,8 +19,6 @@ import io.gravitee.kubernetes.client.KubernetesClient;
 import io.gravitee.node.api.certificate.KeyStoreLoader;
 import io.gravitee.node.api.certificate.KeyStoreLoaderFactory;
 import io.gravitee.node.api.certificate.KeyStoreLoaderOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/gravitee-node-kubernetes/src/test/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesConfigMapKeyStoreLoaderTest.java
+++ b/gravitee-node-kubernetes/src/test/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesConfigMapKeyStoreLoaderTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import io.gravitee.kubernetes.client.KubernetesClient;
+import io.gravitee.kubernetes.client.api.ResourceQuery;
 import io.gravitee.kubernetes.client.model.v1.ConfigMap;
 import io.gravitee.kubernetes.client.model.v1.ObjectMeta;
 import io.gravitee.node.api.certificate.KeyStoreBundle;
@@ -75,7 +76,9 @@ public class KubernetesConfigMapKeyStoreLoaderTest {
         metadata.setNamespace("gio");
         configMap.setMetadata(metadata);
 
-        Mockito.when(kubernetesClient.get("/gio/configmaps/my-configmap", ConfigMap.class)).thenReturn(Maybe.just(configMap));
+        Mockito
+            .when(kubernetesClient.get(ResourceQuery.<ConfigMap>from("/gio/configmaps/my-configmap").build()))
+            .thenReturn(Maybe.just(configMap));
 
         AtomicReference<KeyStoreBundle> bundleRef = new AtomicReference<>(null);
         cut.addListener(bundleRef::set);
@@ -111,7 +114,9 @@ public class KubernetesConfigMapKeyStoreLoaderTest {
         metadata.setNamespace("gio");
         configMap.setMetadata(metadata);
 
-        Mockito.when(kubernetesClient.get("/gio/configmaps/my-configmap", ConfigMap.class)).thenReturn(Maybe.just(configMap));
+        Mockito
+            .when(kubernetesClient.get(ResourceQuery.<ConfigMap>from("/gio/configmaps/my-configmap").build()))
+            .thenReturn(Maybe.just(configMap));
 
         AtomicReference<KeyStoreBundle> bundleRef = new AtomicReference<>(null);
         cut.addListener(bundleRef::set);

--- a/pom.xml
+++ b/pom.xml
@@ -221,22 +221,22 @@
     </dependencies>
 
     <properties>
-        <gravitee-bom.version>2.0</gravitee-bom.version>
+        <gravitee-bom.version>2.5</gravitee-bom.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
-        <gravitee-plugin.version>1.17.1</gravitee-plugin.version>
-        <gravitee-expression-language.version>1.7.2</gravitee-expression-language.version>
-        <gravitee-reporter-api.version>1.17.1</gravitee-reporter-api.version>
+        <gravitee-plugin.version>1.22.0</gravitee-plugin.version>
+        <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
+        <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-	    <gravitee-kubernetes-client.version>0.2.2</gravitee-kubernetes-client.version>
-        <snakeyaml.version>1.29</snakeyaml.version>
-        <hazelcast.version>4.1.8</hazelcast.version>
+        <gravitee-kubernetes-client.version>0.3.0</gravitee-kubernetes-client.version>
+        <snakeyaml.version>1.30</snakeyaml.version>
+        <hazelcast.version>4.1.9</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
 
         <!-- WARNING: the next two dependencies versions must be kept in sync regarding vertx-micrometer-metrics -->
         <micrometer-registry-prometheus.version>1.6.2</micrometer-registry-prometheus.version>
         <LatencyUtils.version>2.0.3</LatencyUtils.version>
         <bouncycastle.version>1.70</bouncycastle.version>
-        <guava.version>31.0.1-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.23.0-7019-k8s-client-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.23.0-7019-k8s-client-SNAPSHOT/gravitee-node-1.23.0-7019-k8s-client-SNAPSHOT.zip)
  <!-- Version placeholder end -->
