### PR TITLE
fix: npe when stopping due to license invalid

### DIFF
--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/infos/NodeInfosService.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/infos/NodeInfosService.java
@@ -91,6 +91,10 @@ public class NodeInfosService extends AbstractService<NodeInfosService> {
   }
 
   public NodeInfosService preStop() {
+    if (nodeInfos == null) {
+      return this;
+    }
+
     nodeInfos.setStatus(NodeStatus.STOPPED);
     messageProducer.write(nodeInfos);
 


### PR DESCRIPTION
When the node were stopping during the license check, we were having a NPE on the `nodeInfos`.
Our hypothesis is that as the node didn't complete the startup process, the `nodeInfos` has never been initialized. Therefore, a simple null check should be enough.

Ex:

```
09:43:44.455 [main] ERROR c.g.l.node.service.LicenseService - License is expired. Please contact GraviteeSource to ask for a renewed license.
09:43:44.456 [main] INFO  c.g.l.n.deployer.WrappedLicensedNode - Gravitee.io - Cockpit Management API is stopping
09:43:44.461 [main] ERROR c.g.l.n.deployer.WrappedLicensedNode - An error occurred while pre-stopping component NodeInfosService
java.lang.NullPointerException: Cannot invoke "io.gravitee.node.api.infos.NodeInfos.setStatus(io.gravitee.node.api.infos.NodeStatus)" because "this.nodeInfos" is null
	at io.gravitee.node.monitoring.infos.NodeInfosService.preStop(NodeInfosService.java:94)
	at io.gravitee.node.monitoring.infos.NodeInfosService.preStop(NodeInfosService.java:46)
	at io.gravitee.node.container.AbstractNode.preStopComponents(AbstractNode.java:247)
	at io.gravitee.node.container.AbstractNode.doStop(AbstractNode.java:138)
	at io.gravitee.common.component.AbstractLifecycleComponent.stop(AbstractLifecycleComponent.java:41)
	at com.graviteesource.license.node.service.LicenseService.stopNode(LicenseService.java:278)
	at com.graviteesource.license.node.service.LicenseService.verify(LicenseService.java:180)
	at com.graviteesource.license.node.service.LicenseService.reload(LicenseService.java:160)
	at com.graviteesource.license.node.service.LicenseService.doStart(LicenseService.java:101)
	at io.gravitee.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:32)
	at io.gravitee.node.container.AbstractNode.startComponents(AbstractNode.java:202)
	at io.gravitee.node.container.AbstractNode.doStart(AbstractNode.java:76)
	at com.graviteesource.license.node.AbstractLicensedNode.doStart(AbstractLicensedNode.java:31)
	at io.gravitee.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:32)
	at io.gravitee.node.container.AbstractContainer.doStart(AbstractContainer.java:106)
	at io.gravitee.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:32)
	at com.graviteesource.cockpit.management.standalone.container.ManagementContainer.main(ManagementContainer.java:29)
```
