### PR TITLE
fix(vertx-node): make use of the default clientAuth in HttpServer configuration

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/configuration/HttpServerConfiguration.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/configuration/HttpServerConfiguration.java
@@ -301,7 +301,7 @@ public class HttpServerConfiguration {
     private boolean perFrameWebSocketCompressionSupported = true;
     private boolean proxyProtocol;
     private long proxyProtocolTimeout = 10000;
-    private ClientAuth clientAuth;
+    private ClientAuth clientAuth = ClientAuth.NONE;
     private List<String> authorizedTlsCipherSuites;
 
     private Environment environment;
@@ -672,7 +672,7 @@ public class HttpServerConfiguration {
 
       String sClientAuthMode = environment.getProperty(
         prefix + "ssl.clientAuth",
-        ClientAuth.NONE.name()
+        this.clientAuth.name()
       );
       if (sClientAuthMode.equalsIgnoreCase(Boolean.TRUE.toString())) {
         this.clientAuth = ClientAuth.REQUIRED;


### PR DESCRIPTION
## Issue

When creating an `HttpServerConfiguration`, it is impossible to define a default value for the field `clientAuth`.

The one defined via the method `withDefaultClientAuth` is ignored when building the final object.
