### PR TITLE
[1.20.x] fix http server config defaults

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/configuration/HttpServerConfiguration.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/configuration/HttpServerConfiguration.java
@@ -301,7 +301,7 @@ public class HttpServerConfiguration {
     private boolean perFrameWebSocketCompressionSupported = true;
     private boolean proxyProtocol;
     private long proxyProtocolTimeout = 10000;
-    private ClientAuth clientAuth;
+    private ClientAuth clientAuth = ClientAuth.NONE;
     private List<String> authorizedTlsCipherSuites;
 
     private Environment environment;
@@ -672,7 +672,7 @@ public class HttpServerConfiguration {
 
       String sClientAuthMode = environment.getProperty(
         prefix + "ssl.clientAuth",
-        ClientAuth.NONE.name()
+        this.clientAuth.name()
       );
       if (sClientAuthMode.equalsIgnoreCase(Boolean.TRUE.toString())) {
         this.clientAuth = ClientAuth.REQUIRED;

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/configuration/HttpServerConfiguration.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/configuration/HttpServerConfiguration.java
@@ -598,7 +598,10 @@ public class HttpServerConfiguration {
       return certificates;
     }
 
-    private List<String> getArrayValues(String prefix) {
+    private List<String> getArrayValues(
+      String prefix,
+      List<String> defaultValue
+    ) {
       final List<String> values = new ArrayList<>();
 
       boolean found = true;
@@ -619,6 +622,10 @@ public class HttpServerConfiguration {
         if (single != null && !single.isEmpty()) {
           values.add(single);
         }
+      }
+
+      if (values.isEmpty() && defaultValue != null) {
+        return defaultValue;
       }
 
       return values;
@@ -689,7 +696,10 @@ public class HttpServerConfiguration {
       this.keyStoreCertificates =
         getCertificateValues(prefix + "ssl.keystore.certificates");
       this.keyStoreKubernetes =
-        getArrayValues(prefix + "ssl.keystore.kubernetes");
+        getArrayValues(
+          prefix + "ssl.keystore.kubernetes",
+          this.keyStoreKubernetes
+        );
       this.keyStoreDefaultAlias =
         environment.getProperty(prefix + "ssl.keystore.defaultAlias");
       this.keyStorePassword =
@@ -702,7 +712,8 @@ public class HttpServerConfiguration {
         environment.getProperty(prefix + "ssl.truststore.type", trustStoreType);
       this.trustStorePath =
         environment.getProperty(prefix + "ssl.truststore.path", trustStorePath);
-      this.trustStorePaths = getArrayValues(prefix + "ssl.truststore.path");
+      this.trustStorePaths =
+        getArrayValues(prefix + "ssl.truststore.path", this.trustStorePaths);
       this.trustStorePassword =
         environment.getProperty(
           prefix + "ssl.truststore.password",


### PR DESCRIPTION
## Issue

When creating an `HttpServerConfiguration`, it is impossible to define default values for the fields `clientAuth`, `keyStoreKubernetes` and `trustStorePaths `.

The ones defined via the method `withDefault<fieldName>` are ignored when building the final object.
