### PR TITLE
Implement upgrader framework

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/initializer/Initializer.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/initializer/Initializer.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.initializer;
+
+/**
+ * Initializer will run each upgrade
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface Initializer {
+    boolean initialize();
+
+    int getOrder();
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/UpgradeRecord.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/UpgradeRecord.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.upgrader;
+
+import java.util.Date;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UpgradeRecord {
+
+    /**
+     * The unique identifier of the Upgrader object.
+     */
+    private String id;
+
+    /**
+     * date that the Upgrader is applied
+     */
+    private Date appliedAt;
+
+    public UpgradeRecord() {}
+
+    public UpgradeRecord(String id, Date appliedAt) {
+        this.id = id;
+        this.appliedAt = appliedAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Date getAppliedAt() {
+        return appliedAt;
+    }
+
+    public void setAppliedAt(Date appliedAt) {
+        this.appliedAt = appliedAt;
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/Upgrader.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/Upgrader.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.upgrader;
+
+/**
+ * An upgrader runs only once to populate or modify data in the database
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface Upgrader {
+    boolean upgrade();
+
+    int getOrder();
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/UpgraderRepository.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/UpgraderRepository.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.upgrader;
+
+import io.gravitee.node.api.upgrader.UpgradeRecord;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface UpgraderRepository {
+    /**
+     * @param id the upgrader identifier.
+     * @return the {@link UpgradeRecord} found or none if no corresponding upgrader object has been found.
+     */
+    Maybe<UpgradeRecord> findById(String id);
+
+    Single<UpgradeRecord> create(UpgradeRecord upgradeRecord);
+}

--- a/gravitee-node-services/gravitee-node-services-initializer/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-initializer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node.services</groupId>
         <artifactId>gravitee-node-services</artifactId>
-        <version>1.22.0</version>
+        <version>1.26.1</version>
     </parent>
 
     <artifactId>gravitee-node-services-initializer</artifactId>

--- a/gravitee-node-services/gravitee-node-services-initializer/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-initializer/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.node.services</groupId>
+        <artifactId>gravitee-node-services</artifactId>
+        <version>1.22.0</version>
+    </parent>
+
+    <artifactId>gravitee-node-services-initializer</artifactId>
+    <name>Gravitee.io - Node - Services - Initializer</name>
+
+    <dependencies>
+        <!-- Gravitee.io -->
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/gravitee-node-services/gravitee-node-services-initializer/src/main/java/io/gravitee/node/services/initializer/InitializerServiceImpl.java
+++ b/gravitee-node-services/gravitee-node-services-initializer/src/main/java/io/gravitee/node/services/initializer/InitializerServiceImpl.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.services.initializer;
+
+import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.initializer.Initializer;
+import java.util.Comparator;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class InitializerServiceImpl extends AbstractService<InitializerServiceImpl> implements LifecycleComponent<InitializerServiceImpl> {
+
+    private static final Logger logger = LoggerFactory.getLogger(InitializerServiceImpl.class);
+
+    @Override
+    protected String name() {
+        return "Initializer service";
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        Map<String, Initializer> initializerBeans = applicationContext.getBeansOfType(Initializer.class);
+        initializerBeans
+            .values()
+            .stream()
+            .sorted(Comparator.comparing(Initializer::getOrder))
+            .forEach(initializer -> {
+                try {
+                    logger.info("Apply {} ...", initializer.getClass().getSimpleName());
+                    initializer.initialize();
+                } catch (Exception e) {
+                    logger.error("Unable to apply the initializer {}", initializer.getClass().getSimpleName());
+                }
+            });
+    }
+}

--- a/gravitee-node-services/gravitee-node-services-initializer/src/main/java/io/gravitee/node/services/initializer/spring/InitializerConfiguration.java
+++ b/gravitee-node-services/gravitee-node-services-initializer/src/main/java/io/gravitee/node/services/initializer/spring/InitializerConfiguration.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.services.initializer.spring;
+
+import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.node.services.initializer.InitializerServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class InitializerConfiguration {
+
+    @Bean
+    public InitializerServiceImpl initializerService() {
+        return new InitializerServiceImpl();
+    }
+
+    public static List<Class<? extends LifecycleComponent>> getComponents() {
+        List<Class<? extends LifecycleComponent>> components = new ArrayList<>();
+
+        String upgradeMode = System.getProperty("upgrade.mode");
+
+        if (upgradeMode == null || "false".equalsIgnoreCase(upgradeMode)) {
+            components.add(InitializerServiceImpl.class);
+        }
+
+        return components;
+    }
+}

--- a/gravitee-node-services/gravitee-node-services-initializer/src/test/java/io/gravitee/node/services/initializer/InitializerServiceImplTest.java
+++ b/gravitee-node-services/gravitee-node-services-initializer/src/test/java/io/gravitee/node/services/initializer/InitializerServiceImplTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.services.initializer;
+
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.initializer.Initializer;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class InitializerServiceImplTest {
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @InjectMocks
+    private InitializerServiceImpl cut;
+
+    @Test
+    public void shouldInitialize() throws Exception {
+        Map<String, Initializer> beans = new HashMap<>();
+        Initializer mockInitializer = mock(Initializer.class);
+        beans.put("mock", mockInitializer);
+        cut.setApplicationContext(applicationContext);
+
+        when(applicationContext.getBeansOfType(Initializer.class)).thenReturn(beans);
+
+        cut.start();
+
+        verify(mockInitializer, times(1)).initialize();
+    }
+}

--- a/gravitee-node-services/gravitee-node-services-upgrader/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-upgrader/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.node.services</groupId>
+        <artifactId>gravitee-node-services</artifactId>
+        <version>1.22.0</version>
+    </parent>
+
+    <artifactId>gravitee-node-services-upgrader</artifactId>
+    <name>Gravitee.io - Node - Services - Upgrader</name>
+
+    <dependencies>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/gravitee-node-services/gravitee-node-services-upgrader/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-upgrader/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node.services</groupId>
         <artifactId>gravitee-node-services</artifactId>
-        <version>1.22.0</version>
+        <version>1.26.1</version>
     </parent>
 
     <artifactId>gravitee-node-services-upgrader</artifactId>

--- a/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/UpgraderServiceImpl.java
+++ b/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/UpgraderServiceImpl.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.services.upgrader;
+
+import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.upgrader.UpgradeRecord;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderRepository;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class UpgraderServiceImpl extends AbstractService<UpgraderServiceImpl> implements LifecycleComponent<UpgraderServiceImpl> {
+
+    @Autowired
+    @Lazy
+    private UpgraderRepository upgraderRepository;
+
+    @Value("${upgrade.mode:false}")
+    private boolean upgradeMode;
+
+    private static final Logger logger = LoggerFactory.getLogger(UpgraderServiceImpl.class);
+
+    @Override
+    protected String name() {
+        return "Upgrader service";
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        Map<String, Upgrader> upgraderBeans = applicationContext.getBeansOfType(Upgrader.class);
+
+        AtomicBoolean stopUpgrade = new AtomicBoolean(false);
+        upgraderBeans
+            .values()
+            .stream()
+            .sorted(Comparator.comparing(Upgrader::getOrder))
+            .takeWhile(upgrader -> !stopUpgrade.get())
+            .forEach(upgrader -> {
+                String name = upgrader.getClass().getSimpleName();
+                try {
+                    UpgradeRecord upgradeRecord = upgraderRepository.findById(upgrader.getClass().getName()).blockingGet();
+                    if (upgradeRecord != null) {
+                        logger.info("{} is already applied. it will be ignored.", name);
+                    } else {
+                        logger.info("Apply {} ...", name);
+                        if (upgrader.upgrade()) {
+                            upgraderRepository.create(new UpgradeRecord(upgrader.getClass().getName(), new Date()));
+                        } else {
+                            stopUpgrade.set(true);
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.error("Unable to apply {}. Error: ", name, e);
+                }
+            });
+
+        // The UpgraderService is registered to be executed if upgrader.mode property is either null or true
+        //    but we only stop the node if upgrade.mode is set explicitly to "true".
+        //    This is to keep the backward compatibility. Please look at UpgraderConfiguration for more details
+        if (upgradeMode) {
+            Node node = applicationContext.getBean(Node.class);
+            node.preStop();
+            node.stop();
+            node.postStop();
+            System.exit(0);
+        }
+    }
+}

--- a/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/spring/UpgraderConfiguration.java
+++ b/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/spring/UpgraderConfiguration.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.services.upgrader.spring;
+
+import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.node.services.upgrader.UpgraderServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class UpgraderConfiguration {
+
+    @Bean
+    public UpgraderServiceImpl upgraderService() {
+        return new UpgraderServiceImpl();
+    }
+
+    public static List<Class<? extends LifecycleComponent>> getComponents() {
+        List<Class<? extends LifecycleComponent>> components = new ArrayList<>();
+
+        String upgradeMode = System.getProperty("upgrade.mode");
+
+        // upgrade.mode is null if you run the app without passing any argument (e.x: --upgrade.mode=true)
+        // This is to keep the backward compatibility.
+        if (upgradeMode == null || "true".equalsIgnoreCase(upgradeMode)) {
+            components.add(UpgraderServiceImpl.class);
+        }
+
+        // This will avoid running Liquibase in upgrade mode
+        if ("true".equalsIgnoreCase(upgradeMode)) {
+            System.setProperty("management.jdbc.liquibase", "false");
+        }
+
+        return components;
+    }
+}

--- a/gravitee-node-services/gravitee-node-services-upgrader/src/test/java/io/gravitee/node/services/upgrader/UpgraderServiceImplTest.java
+++ b/gravitee-node-services/gravitee-node-services-upgrader/src/test/java/io/gravitee/node/services/upgrader/UpgraderServiceImplTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.services.upgrader;
+
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.upgrader.UpgradeRecord;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderRepository;
+import io.reactivex.Maybe;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UpgraderServiceImplTest {
+
+    @Mock
+    private UpgraderRepository repository;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private Node node;
+
+    @InjectMocks
+    private UpgraderServiceImpl cut;
+
+    @Test
+    public void shouldUpgrade() throws Exception {
+        Map<String, Upgrader> beans = new HashMap<>();
+        Upgrader mockUpgrader = mock(Upgrader.class);
+        beans.put(mockUpgrader.getClass().getName(), mockUpgrader);
+        cut.setApplicationContext(applicationContext);
+
+        when(applicationContext.getBeansOfType(Upgrader.class)).thenReturn(beans);
+        when(mockUpgrader.upgrade()).thenReturn(true);
+        when(repository.findById(mockUpgrader.getClass().getName())).thenReturn(Maybe.empty());
+
+        cut.start();
+
+        verify(repository, times(1)).findById(mockUpgrader.getClass().getName());
+        verify(repository, times(1)).create(any(UpgradeRecord.class));
+        verify(mockUpgrader, times(1)).upgrade();
+        verify(node, times(0)).stop();
+    }
+
+    @Test
+    public void failedUpgrader_ShouldNotUpgrade() throws Exception {
+        Map<String, Upgrader> beans = new HashMap<>();
+        Upgrader mockUpgrader1 = mock(Upgrader.class);
+        beans.put("mockUpgrader1", mockUpgrader1);
+
+        Upgrader mockUpgrader2 = mock(Upgrader.class);
+        beans.put("mockUpgrader2", mockUpgrader2);
+
+        Upgrader mockUpgrader3 = mock(Upgrader.class);
+        beans.put("mockUpgrader3", mockUpgrader3);
+
+        Upgrader mockUpgrader4 = mock(Upgrader.class);
+        beans.put("mockUpgrader4", mockUpgrader4);
+
+        Upgrader mockUpgrader5 = mock(Upgrader.class);
+        beans.put("mockUpgrader5", mockUpgrader5);
+
+        cut.setApplicationContext(applicationContext);
+
+        when(applicationContext.getBeansOfType(Upgrader.class)).thenReturn(beans);
+        when(mockUpgrader1.upgrade()).thenReturn(true);
+        when(repository.findById(mockUpgrader1.getClass().getName())).thenReturn(Maybe.empty());
+        when(mockUpgrader2.upgrade()).thenReturn(true);
+        when(mockUpgrader3.upgrade()).thenReturn(false);
+
+        cut.start();
+
+        verify(repository, times(3)).findById(mockUpgrader1.getClass().getName());
+        verify(repository, times(2)).create(any(UpgradeRecord.class));
+        verify(mockUpgrader1, times(1)).upgrade();
+        verify(mockUpgrader2, times(1)).upgrade();
+        verify(mockUpgrader3, times(1)).upgrade();
+        verify(mockUpgrader4, times(0)).upgrade();
+        verify(mockUpgrader5, times(0)).upgrade();
+        verify(node, times(0)).stop();
+    }
+
+    @Test
+    public void shouldNotUpgrade() throws Exception {
+        Map<String, Upgrader> beans = new HashMap<>();
+        Upgrader mockUpgrader = mock(Upgrader.class);
+        beans.put(mockUpgrader.getClass().getName(), mockUpgrader);
+        cut.setApplicationContext(applicationContext);
+
+        when(applicationContext.getBeansOfType(Upgrader.class)).thenReturn(beans);
+        when(repository.findById(mockUpgrader.getClass().getName()))
+            .thenReturn(Maybe.just(new UpgradeRecord(mockUpgrader.getClass().getName(), new Date())));
+
+        cut.start();
+
+        verify(repository, times(1)).findById(anyString());
+        verify(repository, times(0)).create(any(UpgradeRecord.class));
+        verify(mockUpgrader, times(0)).upgrade();
+        verify(node, times(0)).stop();
+    }
+}

--- a/gravitee-node-services/pom.xml
+++ b/gravitee-node-services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.22.0</version>
+        <version>1.26.1</version>
     </parent>
 
     <groupId>io.gravitee.node.services</groupId>

--- a/gravitee-node-services/pom.xml
+++ b/gravitee-node-services/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.node</groupId>
+        <artifactId>gravitee-node</artifactId>
+        <version>1.22.0</version>
+    </parent>
+
+    <groupId>io.gravitee.node.services</groupId>
+    <artifactId>gravitee-node-services</artifactId>
+    <name>Gravitee.io - Node - Services</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>gravitee-node-services-initializer</module>
+        <module>gravitee-node-services-upgrader</module>
+    </modules>
+
+    <dependencies>
+        <!-- Gravitee.io -->
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>gravitee-node-certificates</module>
         <module>gravitee-node-notifier</module>
         <module>gravitee-node-license</module>
+        <module>gravitee-node-services</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
https://graviteedevops.atlassian.net/browse/ARCHI-71
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.27.0-ARCH-71-Upgrader-Framework-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.27.0-ARCH-71-Upgrader-Framework-SNAPSHOT/gravitee-node-1.27.0-ARCH-71-Upgrader-Framework-SNAPSHOT.zip)
  <!-- Version placeholder end -->
