### PR TITLE
fix: configurable jetty http  header and buffer size

### DIFF
--- a/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpConfiguration.java
+++ b/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpConfiguration.java
@@ -85,6 +85,15 @@ public class JettyHttpConfiguration {
     @Value("${jetty.ssl.truststore.type:#{null}}")
     private String trustStoreType;
 
+    @Value("${jetty.outputBufferSize:32768}")
+    private int outputBufferSize;
+
+    @Value("${jetty.requestHeaderSize:8192}")
+    private int requestHeaderSize;
+
+    @Value("${jetty.responseHeaderSize:8192}")
+    private int responseHeaderSize;
+
     public int getHttpPort() {
         return httpPort;
     }
@@ -243,5 +252,29 @@ public class JettyHttpConfiguration {
 
     public void setTrustStoreType(String trustStoreType) {
         this.trustStoreType = trustStoreType;
+    }
+
+    public int getOutputBufferSize() {
+        return outputBufferSize;
+    }
+
+    public int getRequestHeaderSize() {
+        return requestHeaderSize;
+    }
+
+    public int getResponseHeaderSize() {
+        return responseHeaderSize;
+    }
+
+    public void setOutputBufferSize(int outputBufferSize) {
+        this.outputBufferSize = outputBufferSize;
+    }
+
+    public void setRequestHeaderSize(int requestHeaderSize) {
+        this.requestHeaderSize = requestHeaderSize;
+    }
+
+    public void setResponseHeaderSize(int responseHeaderSize) {
+        this.responseHeaderSize = responseHeaderSize;
     }
 }

--- a/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpServerFactory.java
+++ b/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpServerFactory.java
@@ -65,9 +65,9 @@ public class JettyHttpServerFactory implements FactoryBean<Server> {
 
         // HTTP Configuration
         HttpConfiguration httpConfig = new HttpConfiguration();
-        httpConfig.setOutputBufferSize(32768);
-        httpConfig.setRequestHeaderSize(8192);
-        httpConfig.setResponseHeaderSize(8192);
+        httpConfig.setOutputBufferSize(jettyHttpConfiguration.getOutputBufferSize());
+        httpConfig.setRequestHeaderSize(jettyHttpConfiguration.getRequestHeaderSize());
+        httpConfig.setResponseHeaderSize(jettyHttpConfiguration.getResponseHeaderSize());
         httpConfig.setSendServerVersion(false);
         httpConfig.setSendDateHeader(false);
         httpConfig.setRequestCookieCompliance(CookieCompliance.RFC2965);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7479

**Description**

Added 
```
HttpConfiguration httpConfig = new HttpConfiguration();
httpConfig.setOutputBufferSize(32768);
httpConfig.setRequestHeaderSize(8192);
httpConfig.setResponseHeaderSize(8192);
```

as part of the configuration for jetty

**Additional context**

[Helm charts
](https://github.com/gravitee-io/helm-charts/pull/238)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.21.1-issues-7479-hardcoded-buffer-header-size-options-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.21.1-issues-7479-hardcoded-buffer-header-size-options-SNAPSHOT/gravitee-node-1.21.1-issues-7479-hardcoded-buffer-header-size-options-SNAPSHOT.zip)
  <!-- Version placeholder end -->
