### PR TITLE
feat: allows to include or exclude metrics labels

### DIFF
--- a/gravitee-node-api/pom.xml
+++ b/gravitee-node-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-api</artifactId>

--- a/gravitee-node-cache/pom.xml
+++ b/gravitee-node-cache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache</artifactId>

--- a/gravitee-node-certificates/pom.xml
+++ b/gravitee-node-certificates/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-certificates</artifactId>

--- a/gravitee-node-cluster/pom.xml
+++ b/gravitee-node-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cluster</artifactId>

--- a/gravitee-node-container/pom.xml
+++ b/gravitee-node-container/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-container</artifactId>

--- a/gravitee-node-jetty/pom.xml
+++ b/gravitee-node-jetty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-jetty</artifactId>

--- a/gravitee-node-kubernetes/pom.xml
+++ b/gravitee-node-kubernetes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-kubernetes</artifactId>

--- a/gravitee-node-license/pom.xml
+++ b/gravitee-node-license/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-license</artifactId>

--- a/gravitee-node-management/pom.xml
+++ b/gravitee-node-management/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-management</artifactId>

--- a/gravitee-node-monitoring/pom.xml
+++ b/gravitee-node-monitoring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-monitoring</artifactId>

--- a/gravitee-node-notifier/pom.xml
+++ b/gravitee-node-notifier/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-node</artifactId>
         <groupId>io.gravitee.node</groupId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-node-plugins/gravitee-node-plugins-service/pom.xml
+++ b/gravitee-node-plugins/gravitee-node-plugins-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-plugins</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-plugins-service</artifactId>

--- a/gravitee-node-plugins/pom.xml
+++ b/gravitee-node-plugins/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-plugins</artifactId>

--- a/gravitee-node-reporter/pom.xml
+++ b/gravitee-node-reporter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-reporter</artifactId>

--- a/gravitee-node-tracing/pom.xml
+++ b/gravitee-node-tracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-tracing</artifactId>

--- a/gravitee-node-vertx/pom.xml
+++ b/gravitee-node-vertx/pom.xml
@@ -24,11 +24,15 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>1.24.3</version>
+        <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-vertx</artifactId>
     <name>Gravitee.io - Node - Vert.x Support</name>
+
+    <properties>
+        <mockito-inline.version>3.12.4</mockito-inline.version>
+    </properties>
 
     <dependencies>
         <!-- Gravitee.io -->
@@ -80,6 +84,25 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito-inline.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/metrics/ExcludeTagsFilter.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/metrics/ExcludeTagsFilter.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.metrics;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.reactivex.annotations.NonNull;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ExcludeTagsFilter implements MeterFilter {
+
+    private final String category;
+
+    private final List<String> excludedLabels;
+
+    public ExcludeTagsFilter(String category, List<String> excludedLabels) {
+        this.category = category;
+        this.excludedLabels = excludedLabels;
+    }
+
+    @NonNull
+    @Override
+    public Meter.Id map(@NonNull Meter.Id id) {
+        if (id.getName().startsWith(category)) {
+            final AtomicBoolean filtered = new AtomicBoolean(false);
+
+            List<Tag> tags = stream(id.getTagsAsIterable().spliterator(), false)
+                .map(t -> {
+                    if (!excludedLabels.contains(t.getKey())) {
+                        return t;
+                    }
+
+                    filtered.set(true);
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .collect(toList());
+
+            // When some tags have been excluded, then replace tags collection.
+            if (filtered.get()) {
+                return id.replaceTags(tags);
+            }
+        }
+        return id;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public List<String> getExcludedLabels() {
+        return excludedLabels;
+    }
+}

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/metrics/RenameVertxFilter.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/metrics/RenameVertxFilter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.metrics;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.reactivex.annotations.NonNull;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RenameVertxFilter implements MeterFilter {
+
+    @NonNull
+    @Override
+    public Meter.Id map(Meter.Id id) {
+        if (id.getName().startsWith("vertx.")) {
+            return id.withName(id.getName().substring(6));
+        }
+
+        return id;
+    }
+}

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
@@ -1,0 +1,283 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.Node;
+import io.gravitee.node.tracing.vertx.LazyVertxTracerFactory;
+import io.gravitee.node.vertx.metrics.ExcludeTagsFilter;
+import io.gravitee.node.vertx.verticle.factory.SpringVerticleFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.micrometer.Label;
+import io.vertx.micrometer.MetricsNaming;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
+import java.util.Objects;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class VertxFactoryTest {
+
+    @Mock
+    private Node node;
+
+    @Spy
+    private MockEnvironment environment = new MockEnvironment();
+
+    @Mock
+    private SpringVerticleFactory springVerticleFactory;
+
+    @Mock
+    private LazyVertxTracerFactory vertxTracerFactory;
+
+    @Mock
+    private Vertx vertx;
+
+    @Mock
+    private PrometheusMeterRegistry registry;
+
+    private MockedStatic<Vertx> vertxStatic;
+
+    private MockedStatic<BackendRegistries> registryStatic;
+
+    @InjectMocks
+    private VertxFactory cut;
+
+    @BeforeEach
+    void init() {
+        vertxStatic = Mockito.mockStatic(Vertx.class);
+        registryStatic = Mockito.mockStatic(BackendRegistries.class);
+
+        vertxStatic.when(() -> Vertx.vertx(any(VertxOptions.class))).thenReturn(vertx);
+        registry = spy(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT));
+        registryStatic.when(BackendRegistries::getDefaultNow).thenReturn(registry);
+
+        environment.setProperty("services.metrics.enabled", "false");
+        environment.setProperty("services.tracing.enabled", "false");
+    }
+
+    @AfterEach
+    void cleanup() {
+        vertxStatic.close();
+        registryStatic.close();
+    }
+
+    @Test
+    void shouldEnableMetrics() throws Exception {
+        enableMetrics();
+
+        cut.getObject();
+
+        verify(registry, atLeastOnce()).config();
+    }
+
+    @Test
+    void shouldEnableMetricsWithVertxV3Names() throws Exception {
+        enableMetrics();
+        environment.setProperty("services.metrics.prometheus.naming.version", "3.10");
+
+        try (final MockedStatic<MetricsNaming> staticMetricsNaming = mockStatic(MetricsNaming.class)) {
+            final MetricsNaming v3Naming = new MetricsNaming();
+            staticMetricsNaming.when(MetricsNaming::v3Names).thenReturn(v3Naming);
+            cut.getObject();
+
+            vertxStatic.verify(() ->
+                Vertx.vertx(
+                    argThat(options -> {
+                        final MicrometerMetricsOptions metricsOptions = (MicrometerMetricsOptions) options.getMetricsOptions();
+                        return Objects.equals(v3Naming, metricsOptions.getMetricsNaming());
+                    })
+                )
+            );
+        }
+    }
+
+    @Test
+    void shouldEnableMetricsWithLabels() throws Exception {
+        enableMetrics();
+        environment.setProperty("services.metrics.labels[0]", "local");
+        environment.setProperty("services.metrics.labels[1]", "remote");
+        environment.setProperty("services.metrics.labels[2]", "http_method");
+        environment.setProperty("services.metrics.labels[3]", "http_code");
+
+        cut.getObject();
+
+        vertxStatic.verify(() ->
+            Vertx.vertx(
+                argThat(options -> {
+                    final MicrometerMetricsOptions metricsOptions = (MicrometerMetricsOptions) options.getMetricsOptions();
+                    return metricsOptions.getLabels().containsAll(Set.of(Label.LOCAL, Label.REMOTE, Label.HTTP_METHOD, Label.HTTP_CODE));
+                })
+            )
+        );
+
+        verify(registry, atLeastOnce()).config();
+    }
+
+    @Test
+    void shouldEnableMetricsWithLabelsFromInclude() throws Exception {
+        enableMetrics();
+        environment.setProperty("services.metrics.include.http.client[0]", "remote");
+        environment.setProperty("services.metrics.include.http.client[1]", "http_method");
+        environment.setProperty("services.metrics.include.http.client[2]", "http_code");
+        environment.setProperty("services.metrics.include.http.server[0]", "local");
+
+        cut.getObject();
+
+        vertxStatic.verify(() ->
+            Vertx.vertx(
+                argThat(options -> {
+                    final MicrometerMetricsOptions metricsOptions = (MicrometerMetricsOptions) options.getMetricsOptions();
+                    return metricsOptions.getLabels().containsAll(Set.of(Label.LOCAL, Label.REMOTE, Label.HTTP_METHOD, Label.HTTP_CODE));
+                })
+            )
+        );
+
+        verify(registry, atLeastOnce()).config();
+    }
+
+    @Test
+    void shouldEnableMetricsWithExcludedLabels() throws Exception {
+        enableMetrics();
+        environment.setProperty("services.metrics.labels[0]", "local");
+        environment.setProperty("services.metrics.labels[1]", "remote");
+        environment.setProperty("services.metrics.labels[2]", "http_method");
+        environment.setProperty("services.metrics.labels[3]", "http_code");
+        environment.setProperty("services.metrics.exclude.http.client[0]", "local");
+        environment.setProperty("services.metrics.exclude.http.server[0]", "remote");
+
+        final MeterRegistry.Config registryConfig = spy(registry.config());
+        ReflectionTestUtils.setField(registry, "config", registryConfig);
+
+        cut.getObject();
+
+        vertxStatic.verify(() ->
+            Vertx.vertx(
+                argThat(options -> {
+                    final MicrometerMetricsOptions metricsOptions = (MicrometerMetricsOptions) options.getMetricsOptions();
+                    return metricsOptions.getLabels().containsAll(Set.of(Label.LOCAL, Label.REMOTE, Label.HTTP_METHOD, Label.HTTP_CODE));
+                })
+            )
+        );
+
+        verify(registry, atLeastOnce()).config();
+
+        // Check that the appropriate meter tags filters have been passed to the registry config.
+        verify(registryConfig)
+            .meterFilter(
+                argThat(filter ->
+                    filter instanceof ExcludeTagsFilter &&
+                    ((ExcludeTagsFilter) filter).getCategory().equals("http.client") &&
+                    ((ExcludeTagsFilter) filter).getExcludedLabels().contains("local")
+                )
+            );
+        verify(registryConfig)
+            .meterFilter(
+                argThat(filter ->
+                    filter instanceof ExcludeTagsFilter &&
+                    ((ExcludeTagsFilter) filter).getCategory().equals("http.server") &&
+                    ((ExcludeTagsFilter) filter).getExcludedLabels().contains("remote")
+                )
+            );
+    }
+
+    @Test
+    void shouldEnableMetricsWithExcludedLabelsForAllOtherCategoriesWhenLabelIsNotGloballyIncluded() throws Exception {
+        enableMetrics();
+        environment.setProperty("services.metrics.include.http.client[0]", "remote");
+
+        final MeterRegistry.Config registryConfig = spy(registry.config());
+        ReflectionTestUtils.setField(registry, "config", registryConfig);
+
+        cut.getObject();
+
+        // Only 'local' tag should be added globally because of the include config.
+        vertxStatic.verify(() ->
+            Vertx.vertx(
+                argThat(options -> {
+                    final MicrometerMetricsOptions metricsOptions = (MicrometerMetricsOptions) options.getMetricsOptions();
+                    return metricsOptions.getLabels().containsAll(Set.of(Label.LOCAL, Label.REMOTE, Label.HTTP_METHOD, Label.HTTP_CODE));
+                })
+            )
+        );
+
+        verify(registry, atLeastOnce()).config();
+
+        // Check that 'remote' tags has been excluded for all categories except 'http.client'.
+        verify(registryConfig, atLeastOnce())
+            .meterFilter(
+                argThat(filter ->
+                    filter instanceof ExcludeTagsFilter &&
+                    !((ExcludeTagsFilter) filter).getCategory().equals("http.client") &&
+                    ((ExcludeTagsFilter) filter).getExcludedLabels().contains("remote")
+                )
+            );
+    }
+
+    @Test
+    void shouldEnableMetricsWithoutLabelsFromUnknownCategory() throws Exception {
+        enableMetrics();
+        environment.setProperty("services.metrics.include.unknown[0]", "label1");
+        environment.setProperty("services.metrics.include.http.client[0]", "remote");
+        environment.setProperty("services.metrics.include.http.server[0]", "local");
+
+        cut.getObject();
+
+        vertxStatic.verify(() ->
+            Vertx.vertx(
+                argThat(options -> {
+                    final MicrometerMetricsOptions metricsOptions = (MicrometerMetricsOptions) options.getMetricsOptions();
+                    return metricsOptions.getLabels().containsAll(Set.of(Label.LOCAL, Label.REMOTE));
+                })
+            )
+        );
+
+        verify(registry, atLeastOnce()).config();
+    }
+
+    @Test
+    void shouldDisableMetrics() throws Exception {
+        environment.setProperty("services.metrics.enabled", "false");
+
+        cut.getObject();
+
+        verify(registry, never()).config();
+    }
+
+    private void enableMetrics() {
+        environment.setProperty("services.metrics.enabled", "true");
+        when(node.application()).thenReturn("graviteeio-test");
+        when(node.hostname()).thenReturn("localhost");
+    }
+}

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/metrics/ExcludeTagsFilterTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/metrics/ExcludeTagsFilterTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class ExcludeTagsFilterTest {
+
+    protected static final String CATEGORY = "testCategory";
+
+    @Mock
+    private Meter.Id meterId;
+
+    private ExcludeTagsFilter cut;
+
+    @Test
+    void shouldExcludeSpecifiedLabels() {
+        cut = new ExcludeTagsFilter(CATEGORY, List.of("label1", "label2"));
+
+        when(meterId.getName()).thenReturn(CATEGORY);
+        when(meterId.getTagsAsIterable())
+            .thenReturn(
+                List.of(
+                    Tag.of("a", "valueA"),
+                    Tag.of("b", "valueB"),
+                    Tag.of("label1", "value"),
+                    Tag.of("label2", "value"),
+                    Tag.of("c", "valueC")
+                )
+            );
+
+        cut.map(meterId);
+
+        verify(meterId).replaceTags(List.of(Tag.of("a", "valueA"), Tag.of("b", "valueB"), Tag.of("c", "valueC")));
+    }
+
+    @Test
+    void shouldNotExcludeNotExistingLabels() {
+        cut = new ExcludeTagsFilter(CATEGORY, List.of("label3", "label4"));
+
+        when(meterId.getName()).thenReturn(CATEGORY);
+        when(meterId.getTagsAsIterable())
+            .thenReturn(
+                List.of(
+                    Tag.of("a", "valueA"),
+                    Tag.of("b", "valueB"),
+                    Tag.of("label1", "value"),
+                    Tag.of("label2", "value"),
+                    Tag.of("c", "valueC")
+                )
+            );
+
+        final Meter.Id mapped = cut.map(meterId);
+
+        assertSame(meterId, mapped);
+        verify(meterId, never()).replaceTags(any());
+    }
+
+    @Test
+    void shouldNotExcludeLabelFromAnotherCategory() {
+        cut = new ExcludeTagsFilter("other", List.of("label1", "label2"));
+
+        when(meterId.getName()).thenReturn(CATEGORY);
+
+        final Meter.Id mapped = cut.map(meterId);
+
+        assertSame(meterId, mapped);
+        verify(meterId, never()).replaceTags(any());
+    }
+}

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/metrics/RenameVertxFilterTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/metrics/RenameVertxFilterTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.metrics;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class RenameVertxFilterTest {
+
+    @Mock
+    private Meter.Id meterId;
+
+    private RenameVertxFilter cut;
+
+    @Test
+    void shouldRenameVertxPrefixedMetrics() {
+        cut = new RenameVertxFilter();
+
+        when(meterId.withName(any(String.class))).thenReturn(meterId);
+        when(meterId.getName()).thenReturn("vertx.testCategory");
+
+        cut.map(meterId);
+
+        verify(meterId).withName("testCategory");
+    }
+
+    @Test
+    void shouldNotRenameNotVertxPrefixedMetrics() {
+        cut = new RenameVertxFilter();
+
+        when(meterId.getName()).thenReturn("test.Category");
+
+        cut.map(meterId);
+
+        verify(meterId, never()).withName(any(String.class));
+    }
+}

--- a/gravitee-node-vertx/src/test/resources/logback-test.xml
+++ b/gravitee-node-vertx/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%date{yyyy-MM-dd HH:mm:ss.SSS} [%-5p] %c: %m%n
+			</Pattern>
+		</layout>
+	</appender>
+
+	<!-- only gravitee Logs in debug -->
+	<logger name="io.gravitee" level="debug" additivity="false">
+		<appender-ref ref="CONSOLE" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root level="warn">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>20.3</version>
     </parent>
 
     <groupId>io.gravitee.node</groupId>
     <artifactId>gravitee-node</artifactId>
-    <version>1.24.3</version>
+    <version>1.25.0-8218-prometheus-labels-SNAPSHOT</version>
 
     <name>Gravitee.io - Node</name>
 
@@ -225,6 +225,23 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8218

**Description**

With that PR it is now possible to include or exclude a metric labels (aka tags) for a specific domain (aka category) by specifying it in the configuration.

By default, the following labels are included:

- `local`
- `http_method`
- `http_code`

On the apim gateway, if you want to include the tag `remote` only for the `http.client` (and avoid adding it for other categories, especially http.server), you can specify the following configuration: `gravitee.services.metrics.include.http.client[0]=remote`

You can also try to exclude the tag `local` on the `http.client` category because it is useless (vertx always set the value to '?'), you can add the following configuration: `gravitee.services.metrics.exclude.http.client[0]=local`

To check if the tags have been well taken in account, you can scrap the prometheus endpoint:

```bash
curl -u admin:<PASSWORD> http://localhost:18082/_node/metrics/prometheus
```

Note: don't forget to enable the metrics `gravitee.services.metrics.enabled=true`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.25.0-8218-prometheus-labels-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.25.0-8218-prometheus-labels-SNAPSHOT/gravitee-node-1.25.0-8218-prometheus-labels-SNAPSHOT.zip)
  <!-- Version placeholder end -->
