### PR TITLE
fix: Upgrade dependency to gravitee-kubernetes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
             <dependency>
                 <groupId>io.gravitee.kubernetes</groupId>
                 <artifactId>gravitee-kubernetes-client</artifactId>
-                <version>${gravitee-kubernetes-client.version}</version>
+                <version>${gravitee-kubernetes.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
@@ -252,7 +252,7 @@
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
         <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-kubernetes-client.version>0.3.0</gravitee-kubernetes-client.version>
+        <gravitee-kubernetes.version>0.4.0</gravitee-kubernetes.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <hazelcast.version>4.1.9</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.26.1-kube-client-upgrade-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.26.1-kube-client-upgrade-SNAPSHOT/gravitee-node-1.26.1-kube-client-upgrade-SNAPSHOT.zip)
  <!-- Version placeholder end -->
