### PR TITLE
fix(node-cache): move guava to compile scope instead of provided

### DIFF
--- a/gravitee-node-cache/pom.xml
+++ b/gravitee-node-cache/pom.xml
@@ -51,7 +51,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Vert.x-->


### PR DESCRIPTION
**Issue**

NA

**Description**

Using provided dep means every user of this lib will need to add the dep in his own pom.xml, however, it looks like we are regularly missing that, causing some troubles. As per previous discussion, we want to restrict the usage of provided deps to plugins.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.27.3-guava-compile-scope-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.27.3-guava-compile-scope-SNAPSHOT/gravitee-node-1.27.3-guava-compile-scope-SNAPSHOT.zip)
  <!-- Version placeholder end -->
