### PR TITLE
fix(api): send head before writing response for /monitor

### DIFF
--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorManagementEndpoint.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorManagementEndpoint.java
@@ -70,8 +70,8 @@ public class NodeMonitorManagementEndpoint implements ManagementEndpoint {
 
             response.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
             response.setChunked(true);
-            response.write(mapper.writeValueAsString(root));
             response.setStatusCode(HttpStatusCode.OK_200);
+            response.write(mapper.writeValueAsString(root));
         } catch (JsonProcessingException e) {
             LOGGER.error("Unexpected error while generating monitoring", e);
             response.setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-616

**Description**

For `/_node/monitor`, we tried to set status code after writing the response, but the head was already sent, causing an error

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.24.4-support-616-internal-monitor-apim-3-18-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.24.4-support-616-internal-monitor-apim-3-18-SNAPSHOT/gravitee-node-1.24.4-support-616-internal-monitor-apim-3-18-SNAPSHOT.zip)
  <!-- Version placeholder end -->
