### PR TITLE
feat: move to bom v4 and vertx 4.3.8

### DIFF
--- a/gravitee-node-certificates/src/test/java/io/gravitee/node/certificates/ReloadableKeyManagerTest.java
+++ b/gravitee-node-certificates/src/test/java/io/gravitee/node/certificates/ReloadableKeyManagerTest.java
@@ -17,6 +17,7 @@ package io.gravitee.node.certificates;
 
 import static io.gravitee.node.api.certificate.KeyStoreLoader.CERTIFICATE_FORMAT_PKCS12;
 import static io.gravitee.node.certificates.ReloadableKeyManager.MAX_SNI_DOMAINS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -107,6 +108,38 @@ public class ReloadableKeyManagerTest {
         when(sslSession.getRequestedServerNames()).thenReturn(Collections.emptyList());
 
         assertEquals("localhost", cut.chooseEngineServerAlias("void", null, sslEngine));
+    }
+
+    @Test
+    public void shouldGetPrivateKey() {
+        final KeyStore keyStore = KeyStoreUtils.initFromPath(CERTIFICATE_FORMAT_PKCS12, getPath("all-in-one.p12"), "secret");
+        cut.load("localhost", keyStore, "secret", true);
+
+        assertThat(cut.getPrivateKey("localhost")).isNotNull();
+    }
+
+    @Test
+    public void shouldGetNullPrivateKeyWhenAliasIsUnknown() {
+        final KeyStore keyStore = KeyStoreUtils.initFromPath(CERTIFICATE_FORMAT_PKCS12, getPath("all-in-one.p12"), "secret");
+        cut.load("localhost", keyStore, "secret", true);
+
+        assertThat(cut.getPrivateKey("unknown")).isNull();
+    }
+
+    @Test
+    public void shouldGetCertificateChain() {
+        final KeyStore keyStore = KeyStoreUtils.initFromPath(CERTIFICATE_FORMAT_PKCS12, getPath("all-in-one.p12"), "secret");
+        cut.load("localhost", keyStore, "secret", true);
+
+        assertThat(cut.getCertificateChain("localhost")).isNotNull();
+    }
+
+    @Test
+    public void shouldGetNullCertificateChainWhenAliasIsUnknown() {
+        final KeyStore keyStore = KeyStoreUtils.initFromPath(CERTIFICATE_FORMAT_PKCS12, getPath("all-in-one.p12"), "secret");
+        cut.load("localhost", keyStore, "secret", true);
+
+        assertThat(cut.getCertificateChain(null)).isNull();
     }
 
     @Test

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
@@ -25,6 +25,7 @@ import io.gravitee.node.vertx.metrics.ExcludeTagsFilter;
 import io.gravitee.node.vertx.metrics.RenameVertxFilter;
 import io.gravitee.node.vertx.verticle.factory.SpringVerticleFactory;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/cert/VertxCertificateManager.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/cert/VertxCertificateManager.java
@@ -28,7 +28,7 @@ public class VertxCertificateManager extends BaseCertificateManager {
 
     public VertxCertificateManager(boolean enableSni) {
         super(enableSni);
-        this.keyCertOptions = KeyCertOptions.wrap(keyManager);
+        this.keyCertOptions = new VertxKeyCertOptions(keyManager);
     }
 
     /**

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/cert/VertxKeyCertOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/cert/VertxKeyCertOptions.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.cert;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.net.KeyCertOptions;
+import java.util.function.Function;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class VertxKeyCertOptions implements KeyCertOptions {
+
+    public static final Function<String, X509KeyManager> NULL_MAPPER_FUNCTION = s -> null;
+    private final KeyManagerFactory keyManagerFactory;
+
+    VertxKeyCertOptions(KeyManagerFactory keyManagerFactory) {
+        if (keyManagerFactory == null || keyManagerFactory.getKeyManagers() == null || keyManagerFactory.getKeyManagers().length == 0) {
+            throw new IllegalArgumentException("KeyManagerFactory is not present or is not initialized yet");
+        }
+        this.keyManagerFactory = keyManagerFactory;
+    }
+
+    VertxKeyCertOptions(X509KeyManager keyManager) {
+        this(new VertxKeyManagerFactory(keyManager));
+    }
+
+    private VertxKeyCertOptions(VertxKeyCertOptions other) {
+        this.keyManagerFactory = other.keyManagerFactory;
+    }
+
+    @Override
+    public KeyCertOptions copy() {
+        return new VertxKeyCertOptions(this);
+    }
+
+    @Override
+    public KeyManagerFactory getKeyManagerFactory(Vertx vertx) {
+        return keyManagerFactory;
+    }
+
+    @Override
+    public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) {
+        // Return a mapper function to always return null. This force vertx to directly rely on our own KeyManagerFactory instead of recreating a new one for each server name.
+        // This is mandatory since recent changes occurring internally in vertx SSLHelper (see https://github.com/eclipse-vertx/vert.x/pull/4468/files#diff-349d956034aca2f682714a50163bc83e32b0e5fa5f473840f2bca2d4049539deR344-R351)
+        return NULL_MAPPER_FUNCTION;
+    }
+}

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/cert/VertxKeyManagerFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/cert/VertxKeyManagerFactory.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.cert;
+
+import java.security.KeyStore;
+import java.security.Provider;
+import java.util.Objects;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.KeyManagerFactorySpi;
+import javax.net.ssl.ManagerFactoryParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class VertxKeyManagerFactory extends KeyManagerFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VertxKeyManagerFactory.class);
+    private static final String KEY_MANAGER_FACTORY_ALGORITHM = "no-algorithm";
+    private static final Provider PROVIDER = new Provider("", 1.0, "") {};
+
+    VertxKeyManagerFactory(KeyManager keyManager) {
+        super(new VertxKeyManagerFactory.KeyManagerFactorySpiWrapper(keyManager), PROVIDER, KEY_MANAGER_FACTORY_ALGORITHM);
+    }
+
+    private static class KeyManagerFactorySpiWrapper extends KeyManagerFactorySpi {
+
+        private final KeyManager[] keyManagers;
+
+        private KeyManagerFactorySpiWrapper(KeyManager keyManager) {
+            Objects.requireNonNull(keyManager);
+            this.keyManagers = new KeyManager[] { keyManager };
+        }
+
+        @Override
+        protected void engineInit(KeyStore keyStore, char[] keyStorePassword) {
+            LOGGER.info("Ignoring provided KeyStore");
+        }
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters managerFactoryParameters) {
+            LOGGER.info("Ignoring provided ManagerFactoryParameters");
+        }
+
+        @Override
+        protected KeyManager[] engineGetKeyManagers() {
+            return keyManagers;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>21.0.0</version>
     </parent>
 
     <groupId>io.gravitee.node</groupId>
@@ -247,7 +247,7 @@
     </dependencies>
 
     <properties>
-        <gravitee-bom.version>2.7</gravitee-bom.version>
+        <gravitee-bom.version>4.0.0-alpha.1</gravitee-bom.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
     <properties>
         <gravitee-bom.version>4.0.0-alpha.1</gravitee-bom.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
-        <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
+        <gravitee-plugin.version>1.25.0</gravitee-plugin.version>
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
         <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Upgrade to the latest bom v4 that includes the latest vertx version.
This includes a fix discovered with vertx 4.3.8 when we enable TLS on the apim gateway.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-update-vertx-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.0.0-update-vertx-SNAPSHOT/gravitee-node-3.0.0-update-vertx-SNAPSHOT.zip)
  <!-- Version placeholder end -->
