### PR TITLE
fix(api): load the right property source for /configuration

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/configuration/ConfigurationEndpoint.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/configuration/ConfigurationEndpoint.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.AbstractEnvironment;
-import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.EnumerablePropertySource;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -48,7 +48,7 @@ public class ConfigurationEndpoint implements ManagementEndpoint {
 
     private static final String ENDPOINT_PATH = "/configuration";
 
-    private static final String PROPERTY_SOURCE_CONFIGURATION = "graviteeConfiguration";
+    private static final String PROPERTY_SOURCE_CONFIGURATION = "graviteeYamlConfiguration";
 
     @Autowired
     private AbstractEnvironment environment;
@@ -71,7 +71,7 @@ public class ConfigurationEndpoint implements ManagementEndpoint {
         response.setChunked(true);
 
         // Configuration is coming from gravitee.yml
-        PropertiesPropertySource nodeConfiguration = (PropertiesPropertySource) environment
+        EnumerablePropertySource nodeConfiguration = (EnumerablePropertySource) environment
             .getPropertySources()
             .get(PROPERTY_SOURCE_CONFIGURATION);
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-781

**Description**

Load graviteeYamlConfiguration property source instead of the old graviteeConfiguration
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.25.2-support-781-internal-configuration-apim-3-19-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.25.2-support-781-internal-configuration-apim-3-19-SNAPSHOT/gravitee-node-1.25.2-support-781-internal-configuration-apim-3-19-SNAPSHOT.zip)
  <!-- Version placeholder end -->
