### PR TITLE
Backport fix: avoid spring loading issue with vertx and k8s client

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 
@@ -210,21 +211,22 @@ public class VertxFactory implements FactoryBean<Vertx> {
     }
 
     private Map<String, Set<Label>> readConfiguredLabelsByCategory(final String type) {
-        return Arrays
-            .stream(MetricsDomain.values())
-            .map(MetricsDomain::toCategory)
-            .flatMap(category ->
-                EnvironmentUtils
-                    .getPropertiesStartingWith((ConfigurableEnvironment) environment, "services.metrics." + type + "." + category)
-                    .entrySet()
-                    .stream()
-            )
-            .collect(
-                Collectors.groupingBy(
-                    e -> e.getKey().replaceAll("^services\\.metrics\\." + type + "\\." + "(.*)\\[\\d+]$", "$1"),
-                    Collectors.mapping(e -> toLabel((String) e.getValue()), Collectors.<Label, Set<Label>>toCollection(HashSet::new))
-                )
-            );
+        final Map<String, Set<Label>> labelsByCategory = new HashMap<>();
+
+        for (MetricsDomain metricsDomain : MetricsDomain.values()) {
+            final String category = metricsDomain.toCategory();
+            final Set<Label> labels = new HashSet<>();
+
+            String value;
+            int counter = 0;
+            labelsByCategory.put(category, labels);
+
+            while ((value = environment.getProperty("services.metrics." + type + "." + category + "[" + (counter++) + "]")) != null) {
+                labels.add(toLabel(value));
+            }
+        }
+
+        return labelsByCategory;
     }
 
     private Label toLabel(String label) {


### PR DESCRIPTION
**Issue**
Backport of https://github.com/gravitee-io/gravitee-node/pull/186

https://github.com/gravitee-io/issues/issues/8927
https://gravitee.atlassian.net/browse/APIM-1047

**Description**

Make sure the VertxFactory doesn't try to list all environment properties by using `environment.getProperty("xxx")` instead of `EnvironmentUtils.getPropertiesStartingWith("xxxx")`.

`KubernetesPropertyResolver` needs a `KubernetesClient` which needs a vertx instance. Vertx instance is instantiated with `VertxFactory` which, when a particular configuration is enabled (`service.metrics.enabled`), tries to customize the metrics labels by looking at the configuration. When doing that, it calls `EnvironmentUtils.getPropertiesStartingWith("xxxxxx")` which basically iterates over all the spring property resolvers including  `KubernetesPropertyResolver` -> :boom:

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.27.6-fix-1-27-x-spring-vertx-bean-injection-kub-client-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.27.6-fix-1-27-x-spring-vertx-bean-injection-kub-client-SNAPSHOT/gravitee-node-1.27.6-fix-1-27-x-spring-vertx-bean-injection-kub-client-SNAPSHOT.zip)
  <!-- Version placeholder end -->
