### PR TITLE
fix: remove enforced INFO level for license

### DIFF
--- a/gravitee-node-license/pom.xml
+++ b/gravitee-node-license/pom.xml
@@ -58,14 +58,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
 
         <!-- Spring dependencies -->
         <dependency>

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/LicenseService.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/LicenseService.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.node.license;
 
-import ch.qos.logback.classic.Level;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.license.license3j.License3JLicense;
@@ -118,9 +117,6 @@ public class LicenseService extends AbstractService<LicenseService> {
     @Override
     protected void doStart() throws Exception {
         super.doStart();
-
-        // Ensure log level for license module to INFO
-        ((ch.qos.logback.classic.Logger) logger).setLevel(Level.INFO);
 
         this.loadLicense();
         this.startLicenseChecker();


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AM-506

**Description**

This PR removes the logging level default of License
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.27.6-AM-506-license-logging-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.27.6-AM-506-license-logging-SNAPSHOT/gravitee-node-1.27.6-AM-506-license-logging-SNAPSHOT.zip)
  <!-- Version placeholder end -->
