### PR TITLE
fix: bump kubernetes client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
         <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-kubernetes-client.version>0.3.0</gravitee-kubernetes-client.version>
+        <gravitee-kubernetes-client.version>0.4.1</gravitee-kubernetes-client.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <hazelcast.version>4.1.9</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>


### PR DESCRIPTION
The upgrade is trying to bring latest fixes of kubernetes client into garvitee-node

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.25.4-fix-kuberetes-client-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.25.4-fix-kuberetes-client-SNAPSHOT/gravitee-node-1.25.4-fix-kuberetes-client-SNAPSHOT.zip)
  <!-- Version placeholder end -->
