### PR TITLE
fix: bump hazelcast and snake yml dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,8 +254,8 @@
         <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-kubernetes.version>2.0.1</gravitee-kubernetes.version>
-        <snakeyaml.version>1.30</snakeyaml.version>
-        <hazelcast.version>4.1.9</hazelcast.version>
+        <snakeyaml.version>1.31</snakeyaml.version>
+        <hazelcast.version>4.1.10</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
 
         <!-- WARNING: the next two dependencies versions must be kept in sync regarding vertx-micrometer-metrics -->


### PR DESCRIPTION
This PR bumps dependencies for:
- Hazelcast (CVE-2022-36437)
- SnakeYML (CVE-2022-38749)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-fix-depedency-bumps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.0.0-fix-depedency-bumps-SNAPSHOT/gravitee-node-3.0.0-fix-depedency-bumps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
