### PR TITLE
fix(deps): remove unused gravitee-el dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,13 +164,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.gravitee.el</groupId>
-                <artifactId>gravitee-expression-language</artifactId>
-                <version>${gravitee-expression-language.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>io.gravitee.alert</groupId>
                 <artifactId>gravitee-alert-api</artifactId>
                 <version>${gravitee-alert-api.version}</version>


### PR DESCRIPTION
**Description**

I removed the property but forgot to remove the dependency management entry and maven didn't complain 😢 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-remove-useless-dependency-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.0.1-remove-useless-dependency-SNAPSHOT/gravitee-node-3.0.1-remove-useless-dependency-SNAPSHOT.zip)
  <!-- Version placeholder end -->
