### PR TITLE
fix: handle dry runs in upgraders

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/Upgrader.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/Upgrader.java
@@ -21,6 +21,17 @@ package io.gravitee.node.api.upgrader;
  * @author GraviteeSource Team
  */
 public interface Upgrader {
+    /**
+     * Implementations can override this method to state that they ran without
+     * committing any change. If the return is true, the upgrade will not be stored
+     * and will run again on subsequent executions until the implementation returns false.
+     *
+     * @return true if the upgrader actually committed its changes, false otherwise.
+     */
+    default boolean isDryRun() {
+        return false;
+    }
+
     boolean upgrade();
 
     int getOrder();

--- a/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/UpgraderServiceImpl.java
+++ b/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/UpgraderServiceImpl.java
@@ -73,7 +73,7 @@ public class UpgraderServiceImpl extends AbstractService<UpgraderServiceImpl> im
                         logger.info("{} is already applied. it will be ignored.", name);
                     } else {
                         logger.info("Apply {} ...", name);
-                        if (upgrader.upgrade()) {
+                        if (upgrader.upgrade() && !upgrader.isDryRun()) {
                             upgraderRepository.create(new UpgradeRecord(upgrader.getClass().getName(), new Date())).blockingGet();
                         } else {
                             stopUpgrade.set(true);

--- a/gravitee-node-services/gravitee-node-services-upgrader/src/test/java/io/gravitee/node/services/upgrader/UpgraderServiceImplTest.java
+++ b/gravitee-node-services/gravitee-node-services-upgrader/src/test/java/io/gravitee/node/services/upgrader/UpgraderServiceImplTest.java
@@ -71,6 +71,29 @@ public class UpgraderServiceImplTest {
     }
 
     @Test
+    public void shouldNotStoreDryRuns() throws Exception {
+        Upgrader mockUpgrader = mock(Upgrader.class);
+        when(mockUpgrader.isDryRun()).thenReturn(true);
+        when(mockUpgrader.upgrade()).thenReturn(true);
+
+        Map<String, Upgrader> beans = new HashMap<>();
+        beans.put(mockUpgrader.getClass().getName(), mockUpgrader);
+
+        cut.setApplicationContext(applicationContext);
+
+        when(applicationContext.getBeansOfType(Upgrader.class)).thenReturn(beans);
+
+        when(repository.findById(mockUpgrader.getClass().getName())).thenReturn(Maybe.empty());
+
+        cut.start();
+
+        verify(repository, times(1)).findById(anyString());
+        verify(mockUpgrader, times(1)).upgrade();
+        verify(repository, never()).create(any(UpgradeRecord.class));
+        verify(node, times(0)).stop();
+    }
+
+    @Test
     public void failedUpgrader_ShouldNotUpgrade() throws Exception {
         Map<String, Upgrader> beans = new HashMap<>();
         Upgrader mockUpgrader1 = mock(Upgrader.class);


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.2-fix-dry-run-upgraders-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.0.2-fix-dry-run-upgraders-SNAPSHOT/gravitee-node-3.0.2-fix-dry-run-upgraders-SNAPSHOT.zip)
  <!-- Version placeholder end -->
