### PR TITLE
fix (prometheus): Stream scraping output instead of using a single St…

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpoint.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpoint.java
@@ -15,17 +15,28 @@
  */
 package io.gravitee.node.management.http.metrics.prometheus;
 
+import static io.prometheus.client.exporter.common.TextFormat.*;
+import static io.vertx.core.http.HttpHeaders.*;
+
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.micrometer.backends.BackendRegistries;
+import java.io.IOException;
+import java.io.Writer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class PrometheusEndpoint implements ManagementEndpoint {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PrometheusEndpoint.class);
 
     @Override
     public HttpMethod method() {
@@ -39,7 +50,72 @@ public class PrometheusEndpoint implements ManagementEndpoint {
 
     @Override
     public void handle(RoutingContext routingContext) {
-        String response = ((PrometheusMeterRegistry) BackendRegistries.getDefaultNow()).scrape();
-        routingContext.response().end(response);
+        PrometheusMeterRegistry registry = (PrometheusMeterRegistry) BackendRegistries.getDefaultNow();
+        HttpServerResponse response = routingContext.response();
+
+        response.putHeader(CONTENT_TYPE, CONTENT_TYPE_004);
+        response.setChunked(true);
+
+        try (BufferWriter writer = new BufferWriter(response)) {
+            registry.scrape(writer);
+        } catch (IOException ioe) {
+            LOGGER.error("Unexpected error while scraping the Prometheus endpoint", ioe);
+            response.close();
+        }
+    }
+
+    private static class BufferWriter extends Writer {
+
+        private final HttpServerResponse response;
+
+        private BufferWriter(HttpServerResponse response) {
+            this.response = response;
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            push(Buffer.buffer(charArrayToByteArray(cbuf)));
+        }
+
+        @Override
+        public void write(int c) throws IOException {
+            push(Buffer.buffer(1).appendByte((byte) (c & 0xFF)));
+        }
+
+        @Override
+        public void write(char[] cbuf) throws IOException {
+            push(Buffer.buffer(new String(cbuf)));
+        }
+
+        @Override
+        public void write(String str) throws IOException {
+            push(Buffer.buffer(str));
+        }
+
+        @Override
+        public void write(String str, int off, int len) throws IOException {
+            push(Buffer.buffer(str));
+        }
+
+        private void push(Buffer buffer) {
+            response.write(buffer);
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() throws IOException {
+            response.end();
+        }
+    }
+
+    private static byte[] charArrayToByteArray(char[] charBuf) {
+        if (charBuf == null) return null;
+        int iLen = charBuf.length;
+        byte[] buf = new byte[iLen];
+        for (int p = 0; p < iLen; p++) buf[p] = (byte) (charBuf[p]);
+
+        return buf;
     }
 }


### PR DESCRIPTION
…ring instance.

**Issue**

https://github.com/gravitee-io/issues/issues/8976

**Description**

Replace the String scraping to a stream scraping.

**Additional context**

This needs a large Micrometer / Prometheus registry to reproduce the OOM

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.24.6`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/1.24.6/gravitee-node-1.24.6.zip)
  <!-- Version placeholder end -->
