### PR TITLE
fix: prevent scheduleNextAttempt to happen if trigger is stopped

### DIFF
--- a/gravitee-node-notifier/src/main/java/io/gravitee/node/notifier/trigger/NotificationTrigger.java
+++ b/gravitee-node-notifier/src/main/java/io/gravitee/node/notifier/trigger/NotificationTrigger.java
@@ -102,14 +102,12 @@ public class NotificationTrigger implements Handler<Long> {
     }
 
     public void stop() {
-        if (started.get() && this.scheduledTaskId != null) {
-            LOGGER.debug("Notification Trigger cancelled !");
+        started.set(false);
+        if (this.scheduledTaskId != null) {
             this.vertx.cancelTimer(this.scheduledTaskId);
-            started.set(false);
-            this.scheduledTaskId = null;
-        } else {
-            LOGGER.debug("Notification Trigger can't be cancelled or doesn't exist");
         }
+        this.scheduledTaskId = null;
+        LOGGER.debug("Notification Trigger cancelled !");
     }
 
     private long computeNextAttempt() {

--- a/gravitee-node-notifier/src/main/java/io/gravitee/node/notifier/trigger/NotificationTrigger.java
+++ b/gravitee-node-notifier/src/main/java/io/gravitee/node/notifier/trigger/NotificationTrigger.java
@@ -189,14 +189,15 @@ public class NotificationTrigger implements Handler<Long> {
 
                                                 //trigger a new attempt
                                                 saveAcknowledge
-                                                    .doOnError(error ->
+                                                    .onErrorResumeNext(error -> {
                                                         LOGGER.warn(
                                                             "Unable to store acknowledge for notification with audience {} and resource {}",
                                                             definition.getAudienceId(),
                                                             definition.getResourceId(),
                                                             error
-                                                        )
-                                                    )
+                                                        );
+                                                        return Single.just(notificationAcknowledge);
+                                                    })
                                                     .doFinally(this::scheduleNextAttempt)
                                                     .subscribe();
                                             }

--- a/gravitee-node-notifier/src/test/java/io/gravitee/node/notifier/trigger/NotificationTriggerTest.java
+++ b/gravitee-node-notifier/src/test/java/io/gravitee/node/notifier/trigger/NotificationTriggerTest.java
@@ -30,9 +30,11 @@ import io.vertx.core.Vertx;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -64,6 +66,11 @@ public class NotificationTriggerTest {
     @Mock
     private Notifier notifier;
 
+    @Before
+    public void setup() {
+        Mockito.reset(vertx);
+    }
+
     @Test
     public void testShouldScheludeIfConditionNotTrue() {
         definition.setCron("*/10 * * * * *");
@@ -80,11 +87,13 @@ public class NotificationTriggerTest {
 
         when(condition.test(any())).thenReturn(false);
 
+        cut.start();
         cut.handle(1l);
 
         verify(notificationAcknowledgeRepository, never()).findByResourceIdAndTypeAndAudienceId(any(), any(), any(), any());
         verify(notificationAcknowledgeRepository, never()).create(any());
-        verify(vertx).setTimer(anyLong(), any());
+        verify(vertx, times(2)).setTimer(anyLong(), any());
+        cut.stop();
     }
 
     @Test
@@ -111,6 +120,7 @@ public class NotificationTriggerTest {
         when(notifier.send(any(), any())).thenReturn(CompletableFuture.allOf());
         when(notificationAcknowledgeRepository.create(any())).thenReturn(Single.just(new NotificationAcknowledge()));
 
+        cut.start();
         cut.handle(1l);
 
         Thread.sleep(2000);
@@ -118,6 +128,45 @@ public class NotificationTriggerTest {
         verify(notificationAcknowledgeRepository, atLeast(1)).findByResourceIdAndTypeAndAudienceId(any(), any(), any(), any());
         verify(notificationAcknowledgeRepository)
             .create(argThat(na -> na.getResourceId().equals("notifid") && na.getType().equals("email")));
+        verify(vertx, times(2)).setTimer(anyLong(), any());
+
+        cut.stop();
+    }
+
+    @Test
+    public void testShouldNotify_onlyOnce_when_stopped() throws Exception {
+        definition.setCron("*/10 * * * * *");
+        definition.setResourceId("notifid");
+        definition.setAudienceId("audid");
+        definition.setType("email");
+
+        NotificationTrigger cut = new NotificationTrigger(
+            vertx,
+            notificationAcknowledgeRepository,
+            notifierFactory,
+            definition,
+            condition,
+            resendCondition,
+            true
+        );
+
+        when(condition.test(any())).thenReturn(true);
+        when(notificationAcknowledgeRepository.findByResourceIdAndTypeAndAudienceId(any(), any(), any(), any()))
+            .thenReturn(Maybe.empty(), Maybe.just(new NotificationAcknowledge()));
+        when(notifierFactory.create(any())).thenReturn(Optional.of(notifier));
+        when(notifier.send(any(), any())).thenReturn(CompletableFuture.allOf());
+        when(notificationAcknowledgeRepository.create(any())).thenReturn(Single.just(new NotificationAcknowledge()));
+
+        cut.start();
+        cut.stop();
+        cut.handle(1l);
+
+        Thread.sleep(2000);
+
+        verify(notificationAcknowledgeRepository, atLeast(1)).findByResourceIdAndTypeAndAudienceId(any(), any(), any(), any());
+        verify(notificationAcknowledgeRepository)
+            .create(argThat(na -> na.getResourceId().equals("notifid") && na.getType().equals("email")));
+        verify(vertx, times(1)).setTimer(anyLong(), any());
     }
 
     @Test
@@ -141,7 +190,7 @@ public class NotificationTriggerTest {
         when(resendCondition.apply(any(), any())).thenReturn(false);
         when(notificationAcknowledgeRepository.findByResourceIdAndTypeAndAudienceId(any(), any(), any(), any()))
             .thenReturn(Maybe.just(new NotificationAcknowledge()));
-
+        cut.start();
         cut.handle(1l);
 
         Thread.sleep(2000);
@@ -149,6 +198,7 @@ public class NotificationTriggerTest {
         verify(notificationAcknowledgeRepository, atLeast(1)).findByResourceIdAndTypeAndAudienceId(any(), any(), any(), any());
         verify(notificationAcknowledgeRepository, never()).create(any());
         verify(notificationAcknowledgeRepository, never()).update(any());
+        cut.stop();
     }
 
     @Test
@@ -182,6 +232,7 @@ public class NotificationTriggerTest {
         when(notifierFactory.create(any())).thenReturn(Optional.of(notifier));
         when(notifier.send(any(), any())).thenReturn(CompletableFuture.allOf());
 
+        cut.start();
         cut.handle(1l);
 
         Thread.sleep(2000);
@@ -190,5 +241,6 @@ public class NotificationTriggerTest {
         verify(notificationAcknowledgeRepository, never()).create(any());
         verify(notificationAcknowledgeRepository)
             .update(argThat(na -> na.getResourceId().equals("notifid") && na.getType().equals("email")));
+        cut.stop();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>0.18</version>
                 <configuration>
                     <nodeVersion>12.13.0</nodeVersion>
                     <prettierJavaVersion>1.6.1</prettierJavaVersion>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/COC-223

**Description**

This PR prevents the `scheduleNextAttempt` step to happen is the NotificationTrigger is already closed with a `started` flag.

**Additional context**

When calling `NotifierService.unregister` and subsequently `NotifierService.stopAndRemoveTrigger`, the `NotificationTrigger` can be in its `handle` phase. 

If we call `NotificationTrigger.stop` at the same time, a new timer will be created and there is no possibility of stopping the timer ever again due to the loss of reference of this trigger in the `NotifierService`.

This also creates a memory leak and a loss of performance since the `NotificationTrigger` keeps looping over until the node is restarted

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.5-fix-notifier-rescheduled-when-stopped-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.0.5-fix-notifier-rescheduled-when-stopped-SNAPSHOT/gravitee-node-3.0.5-fix-notifier-rescheduled-when-stopped-SNAPSHOT.zip)
  <!-- Version placeholder end -->
