### PR TITLE
Fix use simple hazelcast topic

### DIFF
--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastClusterManager.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastClusterManager.java
@@ -83,7 +83,7 @@ public class HazelcastClusterManager extends AbstractService<ClusterManager> imp
 
     @Override
     public <T> Topic<T> topic(final String name) {
-        ITopic<T> iTopic = hazelcastInstance.getReliableTopic(name);
+        ITopic<T> iTopic = hazelcastInstance.getTopic(name);
         return new HazelcastTopic<>(iTopic);
     }
 


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-fix-use-simple-hazelcast-topic-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.1.0-fix-use-simple-hazelcast-topic-SNAPSHOT/gravitee-node-3.1.0-fix-use-simple-hazelcast-topic-SNAPSHOT.zip)
  <!-- Version placeholder end -->
