### PR TITLE
[alpha] fix: bump gravitee-kubernetes version to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
         <gravitee-plugin.version>1.27.0-alpha.2</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-kubernetes.version>2.0.1</gravitee-kubernetes.version>
+        <gravitee-kubernetes.version>2.0.2</gravitee-kubernetes.version>
         <snakeyaml.version>1.31</snakeyaml.version>
         <hazelcast.version>5.2.3</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>


### PR DESCRIPTION
see https://github.com/gravitee-io/gravitee-kubernetes/pull/54

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-fix-kubernetes-client-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.1.0-fix-kubernetes-client-version-SNAPSHOT/gravitee-node-3.1.0-fix-kubernetes-client-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
