### PR TITLE
ARCHI-217: add cluster id on ClusterManager interface

### DIFF
--- a/gravitee-node-api/pom.xml
+++ b/gravitee-node-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-api</artifactId>

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/ClusterManager.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/ClusterManager.java
@@ -25,6 +25,10 @@ import java.util.Set;
  */
 public interface ClusterManager extends Service<ClusterManager> {
     /**
+     * @return the unique cluster identifier
+     */
+    String clusterId();
+    /**
      * @return the current list of members of this cluster
      */
     Set<Member> members();

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/MemberListener.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/MemberListener.java
@@ -23,6 +23,4 @@ public interface MemberListener {
     void onMemberAdded(final Member member);
 
     void onMemberRemoved(final Member member);
-
-    void onMemberChanged(final Member member);
 }

--- a/gravitee-node-cache/gravitee-node-cache-common/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-common</artifactId>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-handler/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-handler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-plugin-handler</artifactId>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-plugin-hazelcast</artifactId>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-standalone/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-standalone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-plugin-standalone</artifactId>

--- a/gravitee-node-cache/pom.xml
+++ b/gravitee-node-cache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache</artifactId>

--- a/gravitee-node-certificates/pom.xml
+++ b/gravitee-node-certificates/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-certificates</artifactId>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cluster</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cluster-plugin-handler</artifactId>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cluster</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cluster-plugin-hazelcast</artifactId>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastClusterManager.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastClusterManager.java
@@ -56,6 +56,11 @@ public class HazelcastClusterManager extends AbstractService<ClusterManager> imp
     }
 
     @Override
+    public String clusterId() {
+        return hazelcastInstance.getConfig().getClusterName();
+    }
+
+    @Override
     public Set<Member> members() {
         return hazelcastInstance
             .getCluster()

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cluster</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cluster-plugin-standalone</artifactId>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/StandaloneClusterManager.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/StandaloneClusterManager.java
@@ -46,6 +46,11 @@ public class StandaloneClusterManager extends AbstractService<ClusterManager> im
     }
 
     @Override
+    public String clusterId() {
+        return "standalone";
+    }
+
+    @Override
     public Set<Member> members() {
         return Set.of(LOCAL_MEMBER);
     }

--- a/gravitee-node-cluster/pom.xml
+++ b/gravitee-node-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.node</groupId>

--- a/gravitee-node-container/pom.xml
+++ b/gravitee-node-container/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-container</artifactId>

--- a/gravitee-node-jetty/pom.xml
+++ b/gravitee-node-jetty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-jetty</artifactId>

--- a/gravitee-node-kubernetes/pom.xml
+++ b/gravitee-node-kubernetes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-kubernetes</artifactId>

--- a/gravitee-node-license/pom.xml
+++ b/gravitee-node-license/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-license</artifactId>

--- a/gravitee-node-management/pom.xml
+++ b/gravitee-node-management/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-management</artifactId>

--- a/gravitee-node-monitoring/pom.xml
+++ b/gravitee-node-monitoring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-monitoring</artifactId>

--- a/gravitee-node-notifier/pom.xml
+++ b/gravitee-node-notifier/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-node</artifactId>
         <groupId>io.gravitee.node</groupId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-node-plugins/gravitee-node-plugins-service/pom.xml
+++ b/gravitee-node-plugins/gravitee-node-plugins-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-plugins</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-plugins-service</artifactId>

--- a/gravitee-node-plugins/pom.xml
+++ b/gravitee-node-plugins/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-plugins</artifactId>

--- a/gravitee-node-reporter/pom.xml
+++ b/gravitee-node-reporter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-reporter</artifactId>

--- a/gravitee-node-services/gravitee-node-services-initializer/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-initializer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node.services</groupId>
         <artifactId>gravitee-node-services</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-services-initializer</artifactId>

--- a/gravitee-node-services/gravitee-node-services-upgrader/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-upgrader/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node.services</groupId>
         <artifactId>gravitee-node-services</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-services-upgrader</artifactId>

--- a/gravitee-node-services/pom.xml
+++ b/gravitee-node-services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.node.services</groupId>

--- a/gravitee-node-tracing/pom.xml
+++ b/gravitee-node-tracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-tracing</artifactId>

--- a/gravitee-node-vertx/pom.xml
+++ b/gravitee-node-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>3.1.0-alpha.8</version>
+        <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-vertx</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.node</groupId>
     <artifactId>gravitee-node</artifactId>
-    <version>3.1.0-alpha.8</version>
+    <version>3.1.0-archi-217-distributed-sync-SNAPSHOT</version>
 
     <name>Gravitee.io - Node</name>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-217

**Description**

Add cluster id on ClusterManager

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-archi-217-distributed-sync-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.1.0-archi-217-distributed-sync-SNAPSHOT/gravitee-node-3.1.0-archi-217-distributed-sync-SNAPSHOT.zip)
  <!-- Version placeholder end -->
