### PR TITLE
chore: bump kubernetes client to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
         <gravitee-plugin.version>1.27.0-alpha.2</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-kubernetes.version>2.0.2</gravitee-kubernetes.version>
+        <gravitee-kubernetes.version>2.0.3</gravitee-kubernetes.version>
         <snakeyaml.version>1.31</snakeyaml.version>
         <hazelcast.version>5.2.3</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>


### PR DESCRIPTION
Bump kubernetes client to 2.0.3