### PR TITLE
fix: avoid npe when evaluating cpu load average

### DIFF
--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorThread.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorThread.java
@@ -80,8 +80,10 @@ public class NodeMonitorThread implements Runnable {
                 // OS metrics
                 OsInfo osInfo = monitor.getOs();
                 event.property("os.cpu.percent", osInfo.cpu.getPercent());
-                for (int i = 0; i < osInfo.cpu.getLoadAverage().length; i++) {
-                    event.property("os.cpu.average." + i, osInfo.cpu.getLoadAverage()[i]);
+                if (osInfo.cpu.getLoadAverage() != null) {
+                    for (int i = 0; i < osInfo.cpu.getLoadAverage().length; i++) {
+                        event.property("os.cpu.average." + i, osInfo.cpu.getLoadAverage()[i]);
+                    }
                 }
 
                 // Process metrics


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1566

**Description**

Avoid NPE if CPU load average is null (which can happen on Windows)

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.9-apim1566-npe-in-monitoring-2-0-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/2.0.9-apim1566-npe-in-monitoring-2-0-SNAPSHOT/gravitee-node-2.0.9-apim1566-npe-in-monitoring-2-0-SNAPSHOT.zip)
  <!-- Version placeholder end -->
