### PR TITLE
chore: bump gravitee-plugin to 2.0.0-alpha1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
     <properties>
         <gravitee-bom.version>4.0.0</gravitee-bom.version>
         <gravitee-common.version>2.1.0</gravitee-common.version>
-        <gravitee-plugin.version>1.27.0-alpha.2</gravitee-plugin.version>
+        <gravitee-plugin.version>2.0.0-alpha.1</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-kubernetes.version>2.0.3</gravitee-kubernetes.version>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-chore-bump-gravitee-plugin-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/3.1.0-chore-bump-gravitee-plugin-SNAPSHOT/gravitee-node-3.1.0-chore-bump-gravitee-plugin-SNAPSHOT.zip)
  <!-- Version placeholder end -->
