### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/gravitee-node-cache/gravitee-node-cache-common/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-common/pom.xml
@@ -46,17 +46,6 @@
             <artifactId>caffeine</artifactId>
             <version>${caffeine.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>${awaitility.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-standalone/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-standalone/pom.xml
@@ -44,11 +44,6 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-node-certificates/pom.xml
+++ b/gravitee-node-certificates/pom.xml
@@ -63,11 +63,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
@@ -50,11 +50,6 @@
             <version>${guava.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-node-cluster/pom.xml
+++ b/gravitee-node-cluster/pom.xml
@@ -27,7 +27,6 @@
         <version>4.0.0-alpha.4</version>
     </parent>
 
-    <groupId>io.gravitee.node</groupId>
     <artifactId>gravitee-node-cluster</artifactId>
     <name>Gravitee.io - Node - Cluster</name>
     <packaging>pom</packaging>

--- a/gravitee-node-notifier/pom.xml
+++ b/gravitee-node-notifier/pom.xml
@@ -63,11 +63,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/gravitee-node-notifier/pom.xml
+++ b/gravitee-node-notifier/pom.xml
@@ -29,11 +29,6 @@
     <artifactId>gravitee-node-notifier</artifactId>
     <name>Gravitee.io - Node - Notifier</name>
 
-    <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.gravitee.node</groupId>

--- a/gravitee-node-notifier/pom.xml
+++ b/gravitee-node-notifier/pom.xml
@@ -29,11 +29,26 @@
     <artifactId>gravitee-node-notifier</artifactId>
     <name>Gravitee.io - Node - Notifier</name>
 
+    <properties>
+        <javax-inject.version>1</javax-inject.version>
+        <jakarta-inject.version>2.0.1</jakarta-inject.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>${javax-inject.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>${jakarta-inject.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-node-notifier/src/main/java/io/gravitee/node/notifier/plugin/impl/NotifierPluginFactoryImpl.java
+++ b/gravitee-node-notifier/src/main/java/io/gravitee/node/notifier/plugin/impl/NotifierPluginFactoryImpl.java
@@ -168,7 +168,7 @@ public class NotifierPluginFactoryImpl implements NotifierPluginFactory {
     }
 
     private Set<Field> lookingForInjectableFields(Class<?> resourceClass) {
-        return ReflectionUtils.getAllFields(resourceClass, withAnnotation(Inject.class));
+        return ReflectionUtils.getAllFields(resourceClass, withAnnotations(Inject.class, jakarta.inject.Inject.class));
     }
 
     public static Predicate<Member> withParametersAssignableFrom(final Class... types) {

--- a/gravitee-node-services/gravitee-node-services-initializer/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-initializer/pom.xml
@@ -30,15 +30,6 @@
     <artifactId>gravitee-node-services-initializer</artifactId>
     <name>Gravitee.io - Node - Services - Initializer</name>
 
-    <dependencies>
-        <!-- Gravitee.io -->
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
-
     <build>
         <resources>
             <resource>

--- a/gravitee-node-services/pom.xml
+++ b/gravitee-node-services/pom.xml
@@ -52,11 +52,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -264,18 +264,18 @@
 
     <properties>
         <gravitee-bom.version>6.0.1</gravitee-bom.version>
-        <gravitee-common.version>2.1.0</gravitee-common.version>
+        <gravitee-common.version>2.1.1</gravitee-common.version>
         <gravitee-plugin.version>2.0.0-alpha.3</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-kubernetes.version>2.0.3</gravitee-kubernetes.version>
-        <snakeyaml.version>1.31</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <hazelcast.version>5.2.3</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <jmockit.version>1.49</jmockit.version>
 
         <!-- WARNING: the next two dependencies versions must be kept in sync regarding vertx-micrometer-metrics -->
-        <micrometer-registry-prometheus.version>1.6.2</micrometer-registry-prometheus.version>
+        <micrometer-registry-prometheus.version>1.10.7</micrometer-registry-prometheus.version>
         <LatencyUtils.version>2.0.3</LatencyUtils.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <guava.version>31.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
     <properties>
         <gravitee-bom.version>6.0.1</gravitee-bom.version>
         <gravitee-common.version>2.1.1</gravitee-common.version>
-        <gravitee-plugin.version>2.0.0-alpha.3</gravitee-plugin.version>
+        <gravitee-plugin.version>2.0.0</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-kubernetes.version>2.0.3</gravitee-kubernetes.version>


### PR DESCRIPTION
**Description**

Bump dependencies.

Supports both javax and jakarta Inject annotation in `gravitee-node-notifier`.

Upgrading gravitee-plugin to 2.0.0 brings an updated gravitee-node-api
which does not declare javax.inject dependencies anynore. This prevented
the compilation of the gravitee-node-notifier module.

This commit adds the javax.inject dependency to fix the compilation. It
also supports the new annotation comming from Jakarta.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.0.0-bump-dependencies-SNAPSHOT/gravitee-node-4.0.0-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
