### PR TITLE
feat: add `am-policy-mfa-challenge` license feature for AM

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -23,6 +23,7 @@ packs:
             - policy-data-logging-masking # for removal
             - apim-policy-geoip-filtering
             - apim-policy-transform-avro-json
+            - am-policy-mfa-challenge
     enterprise-identity-provider:
         features:
             - am-idp-salesforce

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
@@ -153,7 +153,8 @@ class NodeLicenseServiceTest {
                 "apim-en-entrypoint-sse",
                 "apim-reporter-tcp",
                 "policy-data-logging-masking",
-                "am-idp-gateway-handler-saml"
+                "am-idp-gateway-handler-saml",
+                "am-policy-mfa-challenge"
             );
     }
 


### PR DESCRIPTION
related to AM-652

**Description**

Addition of a feature name for the AM policy mfa-challenge
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-AM-652-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.1.0-AM-652-SNAPSHOT/gravitee-node-4.1.0-AM-652-SNAPSHOT.zip)
  <!-- Version placeholder end -->
