### PR TITLE
feat: add AM Account Linking policy

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -24,6 +24,7 @@ packs:
             - apim-policy-geoip-filtering
             - apim-policy-transform-avro-json
             - am-policy-mfa-challenge
+            - am-policy-account-linking
     enterprise-identity-provider:
         features:
             - am-idp-salesforce

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
@@ -154,7 +154,8 @@ class NodeLicenseServiceTest {
                 "apim-reporter-tcp",
                 "policy-data-logging-masking",
                 "am-idp-gateway-handler-saml",
-                "am-policy-mfa-challenge"
+                "am-policy-mfa-challenge",
+                "am-policy-account-linking"
             );
     }
 


### PR DESCRIPTION
closes AM-653
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.0-AM-653-users-account-linking-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.2.0-AM-653-users-account-linking-SNAPSHOT/gravitee-node-4.2.0-AM-653-users-account-linking-SNAPSHOT.zip)
  <!-- Version placeholder end -->
