### PR TITLE
feat: add AM SFR SMS resource plugin

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -53,6 +53,7 @@ packs:
             - am-resource-http-factor
             - am-mfa-sms
             - am-mfa-call
+            - am-resource-sfr
     observability:
         features:
             - apim-reporter-tcp

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
@@ -155,7 +155,8 @@ class NodeLicenseServiceTest {
                 "policy-data-logging-masking",
                 "am-idp-gateway-handler-saml",
                 "am-policy-mfa-challenge",
-                "am-policy-account-linking"
+                "am-policy-account-linking",
+                "am-resource-sfr"
             );
     }
 


### PR DESCRIPTION
closes AM-695
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.0-AM-695-mfa-support-sfr-service-to-send-sms-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.3.0-AM-695-mfa-support-sfr-service-to-send-sms-SNAPSHOT/gravitee-node-4.3.0-AM-695-mfa-support-sfr-service-to-send-sms-SNAPSHOT.zip)
  <!-- Version placeholder end -->
