### PR TITLE
feat: add event native pack to galaxy tier

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -87,6 +87,7 @@ tiers:
             - enterprise-identity-provider
             - observability
             - enterprise-policy
+            - event-native
     universe:
         packs:
             - enterprise-features


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.4.0-feat-galaxy-en-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.4.0-feat-galaxy-en-SNAPSHOT/gravitee-node-4.4.0-feat-galaxy-en-SNAPSHOT.zip)
  <!-- Version placeholder end -->
