### PR TITLE
fix: vertx options reshufling and fixes

### DIFF
--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/server/tcp/VertxTcpServerOptionsTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/server/tcp/VertxTcpServerOptionsTest.java
@@ -217,7 +217,6 @@ class VertxTcpServerOptionsTest {
         final VertxTcpServerOptions options = VertxTcpServerOptions.builder().build();
 
         assertThat(options.getId()).isNotEqualTo(SERVER_ID); // Server id is generated when not provided.
-        assertThat(options.isCompressionSupported()).isEqualTo(DEFAULT_COMPRESSION_SUPPORTED);
         assertThat(options.isTcpKeepAlive()).isEqualTo(DEFAULT_TCP_KEEP_ALIVE);
         assertThat(options.getIdleTimeout()).isEqualTo(DEFAULT_IDLE_TIMEOUT);
         assertThat(options.getHost()).isEqualTo(DEFAULT_LISTENING_HOST);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-267

**Description**

moved compression option into http options
also remove usage of complex regular expression to avoid denial of service attacks
fix a few warning sonar raised

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.4.0-archi-267-vertx-option-fix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.4.0-archi-267-vertx-option-fix-SNAPSHOT/gravitee-node-4.4.0-archi-267-vertx-option-fix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
