### PR TITLE
feat: allow AE as an enterprise feature

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -11,6 +11,7 @@ packs:
             - gravitee-risk-assessment
             - risk-assessment # for removal
             - apim-bridge-gateway
+            - alert-engine
     enterprise-legacy-upgrade:
         features:
             - apim-policy-xslt

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
@@ -156,7 +156,8 @@ class NodeLicenseServiceTest {
                 "am-idp-gateway-handler-saml",
                 "am-policy-mfa-challenge",
                 "am-policy-account-linking",
-                "am-resource-sfr"
+                "am-resource-sfr",
+                "alert-engine"
             );
     }
 


### PR DESCRIPTION
This PR introduces AE as an enterprise feature

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.5.0-feat-handle-ae-as-a-feature-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.5.0-feat-handle-ae-as-a-feature-SNAPSHOT/gravitee-node-4.5.0-feat-handle-ae-as-a-feature-SNAPSHOT.zip)
  <!-- Version placeholder end -->
