### PR TITLE
Update k8s client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-plugin.version>2.1.0-alpha.1</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-kubernetes.version>3.0.1</gravitee-kubernetes.version>
+        <gravitee-kubernetes.version>3.0.2</gravitee-kubernetes.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <hazelcast.version>5.2.3</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>


### PR DESCRIPTION
**Issue**

AM needs to use latest k8s client version following an issue during testing.

**Description**

Update to gravitee-node to lastest K8s client version for AM usage.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.6.0-update-k8s-client-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.6.0-update-k8s-client-version-SNAPSHOT/gravitee-node-4.6.0-update-k8s-client-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
