### PR TITLE
fix: create a pack for alert-engine

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -11,7 +11,6 @@ packs:
             - gravitee-risk-assessment
             - risk-assessment # for removal
             - apim-bridge-gateway
-            - alert-engine
     enterprise-legacy-upgrade:
         features:
             - apim-policy-xslt
@@ -77,6 +76,9 @@ packs:
     enterprise-secret-manager:
         features:
             - gravitee-en-secretprovider-vault
+    enterprise-alert-engine:
+        features:
+            - alert-engine
 
 tiers:
     planet:
@@ -91,6 +93,7 @@ tiers:
             - enterprise-identity-provider
             - observability
             - enterprise-policy
+            - enterprise-alert-engine
     universe:
         packs:
             - enterprise-features
@@ -101,3 +104,4 @@ tiers:
             - event-native
             - enterprise-mfa-factor
             - enterprise-secret-manager
+            - enterprise-alert-engine

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
@@ -88,7 +88,8 @@ class NodeLicenseServiceTest {
                 "observability",
                 "event-native",
                 "enterprise-policy",
-                "enterprise-secret-manager"
+                "enterprise-secret-manager",
+                "enterprise-alert-engine"
             );
     }
 


### PR DESCRIPTION
**Issue**

Recent changes added alert-engine in base entreprise features pack.
When Alert Engine will adopt the node's license framework, that would have added alter engine to all "planet" licenses.

**Description**

* Created a specific pack to that the feature is known in the license model
* Remove AE feature from the entreprise pack
* Add to AE feature "galaxy" and "universe" tiers

This way, when AE adapots node's license framework :
* License with "planet" tier will not infer alert-engine feature, hence it is not added by accident.
* galaxy and universe tier will include AE feature automatically.

** This does not affect the current behaviour, license generator is not impacted **

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.6.0-fix-ae-license-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.6.0-fix-ae-license-SNAPSHOT/gravitee-node-4.6.0-fix-ae-license-SNAPSHOT.zip)
  <!-- Version placeholder end -->
