### PR TITLE
Bump gravitee-plugin to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <properties>
         <gravitee-bom.version>6.0.6</gravitee-bom.version>
         <gravitee-common.version>3.3.3</gravitee-common.version>
-        <gravitee-plugin.version>2.1.0-alpha.1</gravitee-plugin.version>
+        <gravitee-plugin.version>2.2.0</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-kubernetes.version>3.0.2</gravitee-kubernetes.version>


### PR DESCRIPTION
**Issue**

NA

**Description**

Bump gravitee-plugin to 2.2.0

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.6.0-bump-gravitee-plugin-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.6.0-bump-gravitee-plugin-SNAPSHOT/gravitee-node-4.6.0-bump-gravitee-plugin-SNAPSHOT.zip)
  <!-- Version placeholder end -->
