### PR TITLE
fix: defer some sensitive @Value resolution

### DIFF
--- a/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpConfiguration.java
+++ b/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpConfiguration.java
@@ -15,266 +15,110 @@
  */
 package io.gravitee.node.jetty;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
+import io.gravitee.node.api.configuration.Configuration;
+import lombok.RequiredArgsConstructor;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Configuration
+@RequiredArgsConstructor
 public class JettyHttpConfiguration {
 
-    @Value("${jetty.host:0.0.0.0}")
-    private String httpHost;
+    private final Configuration configuration;
 
-    @Value("${jetty.port:8093}")
-    private int httpPort;
-
-    @Value("${jetty.idleTimeout:30000}")
-    private int idleTimeout;
-
-    @Value("${jetty.acceptors:-1}")
-    private int acceptors;
-
-    @Value("${jetty.selectors:-1}")
-    private int selectors;
-
-    @Value("${jetty.pool.minThreads:10}")
-    private int poolMinThreads;
-
-    @Value("${jetty.pool.maxThreads:200}")
-    private int poolMaxThreads;
-
-    @Value("${jetty.pool.idleTimeout:60000}")
-    private int poolIdleTimeout;
-
-    @Value("${jetty.pool.queueSize:6000}")
-    private int poolQueueSize;
-
-    @Value("${jetty.jmx:false}")
-    private boolean jmxEnabled;
-
-    @Value("${jetty.statistics:false}")
-    private boolean statisticsEnabled;
-
-    @Value("${jetty.accesslog.enabled:true}")
-    private boolean accessLogEnabled;
-
-    @Value("${jetty.accesslog.path:${gravitee.home}/logs/gravitee_accesslog_yyyy_mm_dd.log}")
-    private String accessLogPath;
-
-    @Value("${jetty.secured:false}")
-    private boolean secured;
-
-    @Value("${jetty.ssl.keystore.path:#{null}}")
-    private String keyStorePath;
-
-    @Value("${jetty.ssl.keystore.password:#{null}}")
-    private String keyStorePassword;
-
-    @Value("${jetty.ssl.keystore.type:#{null}}")
-    private String keyStoreType;
-
-    @Value("${jetty.ssl.truststore.path:#{null}}")
-    private String trustStorePath;
-
-    @Value("${jetty.ssl.truststore.password:#{null}}")
-    private String trustStorePassword;
-
-    @Value("${jetty.ssl.truststore.type:#{null}}")
-    private String trustStoreType;
-
-    @Value("${jetty.outputBufferSize:32768}")
-    private int outputBufferSize;
-
-    @Value("${jetty.requestHeaderSize:8192}")
-    private int requestHeaderSize;
-
-    @Value("${jetty.responseHeaderSize:8192}")
-    private int responseHeaderSize;
-
-    public int getHttpPort() {
-        return httpPort;
+    public String getHttpHost() {
+        return configuration.getProperty("jetty.host", "0.0.0.0");
     }
 
-    public void setHttpPort(int httpPort) {
-        this.httpPort = httpPort;
+    public int getHttpPort() {
+        return configuration.getProperty("jetty.port", Integer.class, 8093);
     }
 
     public int getAcceptors() {
-        return acceptors;
-    }
-
-    public void setAcceptors(int acceptors) {
-        this.acceptors = acceptors;
+        return configuration.getProperty("jetty.acceptors", Integer.class, -1);
     }
 
     public int getSelectors() {
-        return selectors;
-    }
-
-    public void setSelectors(int selectors) {
-        this.selectors = selectors;
+        return configuration.getProperty("jetty.selectors", Integer.class, -1);
     }
 
     public int getPoolMinThreads() {
-        return poolMinThreads;
-    }
-
-    public void setPoolMinThreads(int poolMinThreads) {
-        this.poolMinThreads = poolMinThreads;
+        return configuration.getProperty("jetty.pool.minThreads", Integer.class, 10);
     }
 
     public int getPoolMaxThreads() {
-        return poolMaxThreads;
-    }
-
-    public void setPoolMaxThreads(int poolMaxThreads) {
-        this.poolMaxThreads = poolMaxThreads;
+        return configuration.getProperty("jetty.pool.maxThreads", Integer.class, 200);
     }
 
     public boolean isJmxEnabled() {
-        return jmxEnabled;
-    }
-
-    public void setJmxEnabled(boolean jmxEnabled) {
-        this.jmxEnabled = jmxEnabled;
+        return configuration.getProperty("jetty.jmx", Boolean.class, false);
     }
 
     public int getIdleTimeout() {
-        return idleTimeout;
-    }
-
-    public void setIdleTimeout(int idleTimeout) {
-        this.idleTimeout = idleTimeout;
+        return configuration.getProperty("jetty.idleTimeout", Integer.class, 30000);
     }
 
     public boolean isStatisticsEnabled() {
-        return statisticsEnabled;
-    }
-
-    public void setStatisticsEnabled(boolean statisticsEnabled) {
-        this.statisticsEnabled = statisticsEnabled;
+        return configuration.getProperty("jetty.statistics", Boolean.class, false);
     }
 
     public int getPoolIdleTimeout() {
-        return poolIdleTimeout;
-    }
-
-    public void setPoolIdleTimeout(int poolIdleTimeout) {
-        this.poolIdleTimeout = poolIdleTimeout;
+        return configuration.getProperty("jetty.pool.idleTimeout", Integer.class, 60000);
     }
 
     public int getPoolQueueSize() {
-        return poolQueueSize;
-    }
-
-    public void setPoolQueueSize(int poolQueueSize) {
-        this.poolQueueSize = poolQueueSize;
+        return configuration.getProperty("jetty.pool.queueSize", Integer.class, 6000);
     }
 
     public boolean isAccessLogEnabled() {
-        return accessLogEnabled;
-    }
-
-    public void setAccessLogEnabled(boolean accessLogEnabled) {
-        this.accessLogEnabled = accessLogEnabled;
+        return configuration.getProperty("jetty.accesslog.enabled", Boolean.class, true);
     }
 
     public String getAccessLogPath() {
-        return accessLogPath;
-    }
-
-    public void setAccessLogPath(String accessLogPath) {
-        this.accessLogPath = accessLogPath;
-    }
-
-    public String getHttpHost() {
-        return httpHost;
-    }
-
-    public void setHttpHost(String httpHost) {
-        this.httpHost = httpHost;
+        return configuration.getProperty(
+            "jetty.accesslog.path",
+            configuration.getProperty("gravitee.home") + "/logs/gravitee_accesslog_yyyy_mm_dd.log"
+        );
     }
 
     public boolean isSecured() {
-        return secured;
-    }
-
-    public void setSecured(boolean secured) {
-        this.secured = secured;
+        return configuration.getProperty("jetty.secured", Boolean.class, false);
     }
 
     public String getKeyStorePath() {
-        return keyStorePath;
-    }
-
-    public void setKeyStorePath(String keyStorePath) {
-        this.keyStorePath = keyStorePath;
+        return configuration.getProperty("jetty.ssl.keystore.path");
     }
 
     public String getKeyStorePassword() {
-        return keyStorePassword;
-    }
-
-    public void setKeyStorePassword(String keyStorePassword) {
-        this.keyStorePassword = keyStorePassword;
+        return configuration.getProperty("jetty.ssl.keystore.password");
     }
 
     public String getTrustStorePath() {
-        return trustStorePath;
-    }
-
-    public void setTrustStorePath(String trustStorePath) {
-        this.trustStorePath = trustStorePath;
+        return configuration.getProperty("jetty.ssl.truststore.path");
     }
 
     public String getTrustStorePassword() {
-        return trustStorePassword;
-    }
-
-    public void setTrustStorePassword(String trustStorePassword) {
-        this.trustStorePassword = trustStorePassword;
+        return configuration.getProperty("jetty.ssl.truststore.password");
     }
 
     public String getKeyStoreType() {
-        return keyStoreType;
-    }
-
-    public void setKeyStoreType(String keyStoreType) {
-        this.keyStoreType = keyStoreType;
+        return configuration.getProperty("jetty.ssl.keystore.type");
     }
 
     public String getTrustStoreType() {
-        return trustStoreType;
+        return configuration.getProperty("jetty.ssl.truststore.type");
     }
 
-    public void setTrustStoreType(String trustStoreType) {
-        this.trustStoreType = trustStoreType;
+    public Integer getOutputBufferSize() {
+        return configuration.getProperty("jetty.outputBufferSize", Integer.class, 32768);
     }
 
-    public int getOutputBufferSize() {
-        return outputBufferSize;
+    public Integer getRequestHeaderSize() {
+        return configuration.getProperty("jetty.requestHeaderSize", Integer.class, 8192);
     }
 
-    public int getRequestHeaderSize() {
-        return requestHeaderSize;
-    }
-
-    public int getResponseHeaderSize() {
-        return responseHeaderSize;
-    }
-
-    public void setOutputBufferSize(int outputBufferSize) {
-        this.outputBufferSize = outputBufferSize;
-    }
-
-    public void setRequestHeaderSize(int requestHeaderSize) {
-        this.requestHeaderSize = requestHeaderSize;
-    }
-
-    public void setResponseHeaderSize(int responseHeaderSize) {
-        this.responseHeaderSize = responseHeaderSize;
+    public Integer getResponseHeaderSize() {
+        return configuration.getProperty("jetty.responseHeaderSize", Integer.class, 8192);
     }
 }

--- a/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpServer.java
+++ b/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpServer.java
@@ -37,6 +37,8 @@ public abstract class JettyHttpServer extends AbstractLifecycleComponent<JettyHt
     private final Logger logger = LoggerFactory.getLogger(JettyHttpServer.class);
 
     @Autowired
+    protected JettyHttpServerFactory serverFactory;
+
     protected Server server;
 
     /**
@@ -46,6 +48,8 @@ public abstract class JettyHttpServer extends AbstractLifecycleComponent<JettyHt
 
     @Override
     protected void doStart() throws Exception {
+        server = serverFactory.getObject();
+
         // This part is needed to avoid WARN while starting container.
         this.attachNoContentHandler();
 
@@ -69,7 +73,9 @@ public abstract class JettyHttpServer extends AbstractLifecycleComponent<JettyHt
 
     @Override
     protected void doStop() throws Exception {
-        server.stop();
+        if (server != null) {
+            server.stop();
+        }
     }
 
     private void attachNoContentHandler() {

--- a/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpServerFactory.java
+++ b/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/JettyHttpServerFactory.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class JettyHttpServerFactory implements FactoryBean<Server> {
 
     private static final String KEYSTORE_TYPE_PKCS12 = "pkcs12";
+    private static final String KEYSTORE_TYPE_JKS = "jks";
 
     @Autowired
     private JettyHttpConfiguration jettyHttpConfiguration;
@@ -84,6 +85,8 @@ public class JettyHttpServerFactory implements FactoryBean<Server> {
             if (jettyHttpConfiguration.getKeyStorePath() != null) {
                 sslContextFactory.setKeyStorePath(jettyHttpConfiguration.getKeyStorePath());
                 sslContextFactory.setKeyStorePassword(jettyHttpConfiguration.getKeyStorePassword());
+                // Force default keystore type to jks for backward compatibility (since jetty moved to pkcs12 by default https://github.com/jetty/jetty.project/pull/4489).
+                sslContextFactory.setKeyStoreType(KEYSTORE_TYPE_JKS);
 
                 if (KEYSTORE_TYPE_PKCS12.equalsIgnoreCase(jettyHttpConfiguration.getKeyStoreType())) {
                     sslContextFactory.setKeyStoreType(KEYSTORE_TYPE_PKCS12);
@@ -93,6 +96,8 @@ public class JettyHttpServerFactory implements FactoryBean<Server> {
             if (jettyHttpConfiguration.getTrustStorePath() != null) {
                 sslContextFactory.setTrustStorePath(jettyHttpConfiguration.getTrustStorePath());
                 sslContextFactory.setTrustStorePassword(jettyHttpConfiguration.getTrustStorePassword());
+                // Force default truststore type to jks for backward compatibility (since jetty moved to pkcs12 by default https://github.com/jetty/jetty.project/pull/4489).
+                sslContextFactory.setTrustStoreType(KEYSTORE_TYPE_JKS);
 
                 if (KEYSTORE_TYPE_PKCS12.equalsIgnoreCase(jettyHttpConfiguration.getTrustStoreType())) {
                     sslContextFactory.setTrustStoreType(KEYSTORE_TYPE_PKCS12);

--- a/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/healthcheck/JettyHttpServerProbe.java
+++ b/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/healthcheck/JettyHttpServerProbe.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.node.jetty.healthcheck;
 
+import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.api.healthcheck.Probe;
 import io.gravitee.node.api.healthcheck.Result;
 import io.vertx.core.Promise;
@@ -23,7 +24,6 @@ import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import java.util.concurrent.CompletionStage;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 /**
  * HTTP Probe used to check the Jetty Http Server is listening.
@@ -34,11 +34,8 @@ import org.springframework.beans.factory.annotation.Value;
  */
 public class JettyHttpServerProbe implements Probe {
 
-    @Value("${jetty.port:8093}")
-    private int port;
-
-    @Value("${jetty.host:localhost}")
-    private String host;
+    @Autowired
+    private Configuration configuration;
 
     @Autowired
     private Vertx vertx;
@@ -56,8 +53,8 @@ public class JettyHttpServerProbe implements Probe {
         NetClient client = vertx.createNetClient(options);
 
         client.connect(
-            port,
-            host,
+            port(),
+            host(),
             res -> {
                 if (res.succeeded()) {
                     promise.complete(Result.healthy());
@@ -70,5 +67,13 @@ public class JettyHttpServerProbe implements Probe {
         );
 
         return promise.future().toCompletionStage();
+    }
+
+    private int port() {
+        return configuration.getProperty("jetty.port", Integer.class, 8093);
+    }
+
+    private String host() {
+        return configuration.getProperty("jetty.host", "localhost");
     }
 }

--- a/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/spring/JettyContainerConfiguration.java
+++ b/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/spring/JettyContainerConfiguration.java
@@ -29,8 +29,8 @@ import org.springframework.context.annotation.Configuration;
 public class JettyContainerConfiguration {
 
     @Bean
-    public JettyHttpConfiguration jettyConfiguration() {
-        return new JettyHttpConfiguration();
+    public JettyHttpConfiguration jettyConfiguration(io.gravitee.node.api.configuration.Configuration configuration) {
+        return new JettyHttpConfiguration(configuration);
     }
 
     @Bean

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/configuration/HttpServerConfiguration.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/configuration/HttpServerConfiguration.java
@@ -15,193 +15,85 @@
  */
 package io.gravitee.node.management.http.vertx.configuration;
 
+import io.gravitee.node.api.configuration.Configuration;
 import io.vertx.core.http.HttpServerOptions;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@RequiredArgsConstructor
 public class HttpServerConfiguration {
 
-    @Value("${services.core.http.enabled:true}")
-    private boolean enabled;
+    private final Configuration configuration;
 
-    @Value("${services.core.http.port:18082}")
-    private int port;
+    public boolean isEnabled() {
+        return configuration.getProperty("services.core.http.enabled", Boolean.class, true);
+    }
 
-    @Value("${services.core.http.host:localhost}")
-    private String host;
+    public int getPort() {
+        return configuration.getProperty("services.core.http.port", Integer.class, 18082);
+    }
 
-    @Value("${services.core.http.authentication.type:basic}")
-    private String authenticationType;
+    public String getHost() {
+        return configuration.getProperty("services.core.http.host", "localhost");
+    }
 
-    @Value("${services.core.http.secured:false}")
-    private boolean secured;
+    public String getAuthenticationType() {
+        return configuration.getProperty("services.core.http.authentication.type", "basic");
+    }
 
-    @Value("${services.core.http.alpn:false}")
-    private boolean alpn;
+    public boolean isSecured() {
+        return configuration.getProperty("services.core.http.secured", Boolean.class, false);
+    }
 
-    @Value("${http.ssl.tlsProtocols:#{null}}")
-    private String tlsProtocols;
+    public boolean isAlpn() {
+        return configuration.getProperty("services.core.http.alpn", Boolean.class, false);
+    }
 
-    @Value("${http.ssl.tlsCiphers:#{null}}")
-    private String tlsCiphers;
+    public String getTlsProtocols() {
+        return configuration.getProperty("services.core.http.ssl.tlsProtocols");
+    }
 
-    @Value("${services.core.http.ssl.keystore.path:#{null}}")
-    private String keyStorePath;
+    public String getTlsCiphers() {
+        return configuration.getProperty("services.core.http.ssl.tlsCiphers");
+    }
 
-    @Value("${services.core.http.ssl.keystore.password:#{null}}")
-    private String keyStorePassword;
+    public String getKeyStorePath() {
+        return configuration.getProperty("services.core.http.ssl.keystore.path");
+    }
 
-    @Value("${services.core.http.ssl.keystore.type:#{null}}")
-    private String keyStoreType;
+    public String getKeyStorePassword() {
+        return configuration.getProperty("services.core.http.ssl.keystore.password");
+    }
 
-    @Value("${services.core.http.ssl.truststore.path:#{null}}")
-    private String trustStorePath;
+    public String getKeyStoreType() {
+        return configuration.getProperty("services.core.http.ssl.keystore.type");
+    }
 
-    @Value("${services.core.http.ssl.truststore.password:#{null}}")
-    private String trustStorePassword;
+    public String getTrustStorePath() {
+        return configuration.getProperty("services.core.http.ssl.truststore.path");
+    }
 
-    @Value("${services.core.http.ssl.truststore.type:#{null}}")
-    private String trustStoreType;
+    public String getTrustStorePassword() {
+        return configuration.getProperty("services.core.http.ssl.truststore.password");
+    }
 
-    @Value("${services.core.http.idleTimeout:" + HttpServerOptions.DEFAULT_IDLE_TIMEOUT + "}")
-    private int idleTimeout;
+    public String getTrustStoreType() {
+        return configuration.getProperty("services.core.http.ssl.truststore.type");
+    }
+
+    public int getIdleTimeout() {
+        return configuration.getProperty("services.core.http.idleTimeout", Integer.class, HttpServerOptions.DEFAULT_IDLE_TIMEOUT);
+    }
 
     /**
      * null  : REQUEST
      * true  : REQUIRED
      * false : NONE
      */
-    @Value("${services.core.http.ssl.clientAuth:#{null}}")
-    private String clientAuth;
-
     public String getClientAuth() {
-        return clientAuth;
-    }
-
-    public void setClientAuth(String clientAuth) {
-        this.clientAuth = clientAuth;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-
-    public String getHost() {
-        return host;
-    }
-
-    public void setHost(String host) {
-        this.host = host;
-    }
-
-    public String getAuthenticationType() {
-        return authenticationType;
-    }
-
-    public void setAuthenticationType(String authenticationType) {
-        this.authenticationType = authenticationType;
-    }
-
-    public boolean isSecured() {
-        return secured;
-    }
-
-    public void setSecured(boolean secured) {
-        this.secured = secured;
-    }
-
-    public boolean isAlpn() {
-        return alpn;
-    }
-
-    public void setAlpn(boolean alpn) {
-        this.alpn = alpn;
-    }
-
-    public String getTlsProtocols() {
-        return tlsProtocols;
-    }
-
-    public void setTlsProtocols(String tlsProtocols) {
-        this.tlsProtocols = tlsProtocols;
-    }
-
-    public String getTlsCiphers() {
-        return tlsCiphers;
-    }
-
-    public void setTlsCiphers(String tlsCiphers) {
-        this.tlsCiphers = tlsCiphers;
-    }
-
-    public String getKeyStorePath() {
-        return keyStorePath;
-    }
-
-    public void setKeyStorePath(String keyStorePath) {
-        this.keyStorePath = keyStorePath;
-    }
-
-    public String getKeyStorePassword() {
-        return keyStorePassword;
-    }
-
-    public void setKeyStorePassword(String keyStorePassword) {
-        this.keyStorePassword = keyStorePassword;
-    }
-
-    public String getKeyStoreType() {
-        return keyStoreType;
-    }
-
-    public void setKeyStoreType(String keyStoreType) {
-        this.keyStoreType = keyStoreType;
-    }
-
-    public String getTrustStorePath() {
-        return trustStorePath;
-    }
-
-    public void setTrustStorePath(String trustStorePath) {
-        this.trustStorePath = trustStorePath;
-    }
-
-    public String getTrustStorePassword() {
-        return trustStorePassword;
-    }
-
-    public void setTrustStorePassword(String trustStorePassword) {
-        this.trustStorePassword = trustStorePassword;
-    }
-
-    public String getTrustStoreType() {
-        return trustStoreType;
-    }
-
-    public void setTrustStoreType(String trustStoreType) {
-        this.trustStoreType = trustStoreType;
-    }
-
-    public int getIdleTimeout() {
-        return idleTimeout;
-    }
-
-    public void setIdleTimeout(int idleTimeout) {
-        this.idleTimeout = idleTimeout;
+        return configuration.getProperty("services.core.http.ssl.clientAuth");
     }
 }

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
@@ -27,6 +27,7 @@ import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.web.Router;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
@@ -53,16 +54,19 @@ public class HttpServerSpringConfiguration {
     }
 
     @Bean("managementHttpServer")
-    public HttpServer httpServer(Vertx vertx) {
+    public HttpServer httpServer(
+        Vertx vertx,
+        @Qualifier("managementHttpServerConfiguration") HttpServerConfiguration httpServerConfiguration
+    ) {
         HttpServerOptions options = new HttpServerOptions()
-            .setPort(httpServerConfiguration().getPort())
-            .setHost(httpServerConfiguration().getHost());
+            .setPort(httpServerConfiguration.getPort())
+            .setHost(httpServerConfiguration.getHost());
 
-        if (httpServerConfiguration().isSecured()) {
-            options.setSsl(httpServerConfiguration().isSecured());
-            options.setUseAlpn(httpServerConfiguration().isAlpn());
+        if (httpServerConfiguration.isSecured()) {
+            options.setSsl(httpServerConfiguration.isSecured());
+            options.setUseAlpn(httpServerConfiguration.isAlpn());
 
-            String clientAuth = httpServerConfiguration().getClientAuth();
+            String clientAuth = httpServerConfiguration.getClientAuth();
             if (!StringUtils.isEmpty(clientAuth)) {
                 if (clientAuth.equalsIgnoreCase(Boolean.TRUE.toString())) {
                     options.setClientAuth(ClientAuth.REQUIRED);
@@ -73,51 +77,51 @@ public class HttpServerSpringConfiguration {
                 options.setClientAuth(ClientAuth.REQUEST);
             }
 
-            if (httpServerConfiguration().getTrustStorePath() != null) {
+            if (httpServerConfiguration.getTrustStorePath() != null) {
                 if (
-                    httpServerConfiguration().getTrustStoreType() == null ||
-                    httpServerConfiguration().getTrustStoreType().isEmpty() ||
-                    httpServerConfiguration().getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_JKS)
+                    httpServerConfiguration.getTrustStoreType() == null ||
+                    httpServerConfiguration.getTrustStoreType().isEmpty() ||
+                    httpServerConfiguration.getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_JKS)
                 ) {
                     options.setTrustStoreOptions(
                         new JksOptions()
-                            .setPath(httpServerConfiguration().getTrustStorePath())
-                            .setPassword(httpServerConfiguration().getTrustStorePassword())
+                            .setPath(httpServerConfiguration.getTrustStorePath())
+                            .setPassword(httpServerConfiguration.getTrustStorePassword())
                     );
-                } else if (httpServerConfiguration().getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM)) {
-                    options.setPemTrustOptions(new PemTrustOptions().addCertPath(httpServerConfiguration().getTrustStorePath()));
-                } else if (httpServerConfiguration().getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PKCS12)) {
+                } else if (httpServerConfiguration.getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM)) {
+                    options.setPemTrustOptions(new PemTrustOptions().addCertPath(httpServerConfiguration.getTrustStorePath()));
+                } else if (httpServerConfiguration.getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PKCS12)) {
                     options.setPfxTrustOptions(
                         new PfxOptions()
-                            .setPath(httpServerConfiguration().getTrustStorePath())
-                            .setPassword(httpServerConfiguration().getTrustStorePassword())
+                            .setPath(httpServerConfiguration.getTrustStorePath())
+                            .setPassword(httpServerConfiguration.getTrustStorePassword())
                     );
                 }
             }
 
-            if (httpServerConfiguration().getKeyStorePath() != null) {
+            if (httpServerConfiguration.getKeyStorePath() != null) {
                 if (
-                    httpServerConfiguration().getKeyStoreType() == null ||
-                    httpServerConfiguration().getKeyStoreType().isEmpty() ||
-                    httpServerConfiguration().getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_JKS)
+                    httpServerConfiguration.getKeyStoreType() == null ||
+                    httpServerConfiguration.getKeyStoreType().isEmpty() ||
+                    httpServerConfiguration.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_JKS)
                 ) {
                     options.setKeyStoreOptions(
                         new JksOptions()
-                            .setPath(httpServerConfiguration().getKeyStorePath())
-                            .setPassword(httpServerConfiguration().getKeyStorePassword())
+                            .setPath(httpServerConfiguration.getKeyStorePath())
+                            .setPassword(httpServerConfiguration.getKeyStorePassword())
                     );
-                } else if (httpServerConfiguration().getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM)) {
-                    options.setPemKeyCertOptions(new PemKeyCertOptions().addCertPath(httpServerConfiguration().getKeyStorePath()));
-                } else if (httpServerConfiguration().getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PKCS12)) {
+                } else if (httpServerConfiguration.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM)) {
+                    options.setPemKeyCertOptions(new PemKeyCertOptions().addCertPath(httpServerConfiguration.getKeyStorePath()));
+                } else if (httpServerConfiguration.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PKCS12)) {
                     options.setPfxKeyCertOptions(
                         new PfxOptions()
-                            .setPath(httpServerConfiguration().getKeyStorePath())
-                            .setPassword(httpServerConfiguration().getKeyStorePassword())
+                            .setPath(httpServerConfiguration.getKeyStorePath())
+                            .setPassword(httpServerConfiguration.getKeyStorePassword())
                     );
                 }
             }
         }
-        options.setIdleTimeout(httpServerConfiguration().getIdleTimeout());
+        options.setIdleTimeout(httpServerConfiguration.getIdleTimeout());
 
         return vertx.createHttpServer(options);
     }
@@ -128,7 +132,7 @@ public class HttpServerSpringConfiguration {
     }
 
     @Bean("managementHttpServerConfiguration")
-    public HttpServerConfiguration httpServerConfiguration() {
-        return new HttpServerConfiguration();
+    public HttpServerConfiguration httpServerConfiguration(io.gravitee.node.api.configuration.Configuration configuration) {
+        return new HttpServerConfiguration(configuration);
     }
 }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/probe/MemoryProbe.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/probe/MemoryProbe.java
@@ -15,11 +15,12 @@
  */
 package io.gravitee.node.monitoring.healthcheck.probe;
 
+import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.api.healthcheck.Probe;
 import io.gravitee.node.api.healthcheck.Result;
 import io.gravitee.node.monitoring.monitor.probe.JvmProbe;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -27,8 +28,8 @@ import org.springframework.beans.factory.annotation.Value;
  */
 public class MemoryProbe implements Probe {
 
-    @Value("${services.health.threshold.memory:80}")
-    private int threshold;
+    @Autowired
+    private Configuration configuration;
 
     @Override
     public String id() {
@@ -44,12 +45,16 @@ public class MemoryProbe implements Probe {
     public CompletableFuture<Result> check() {
         try {
             return CompletableFuture.supplyAsync(() ->
-                JvmProbe.getInstance().jvmInfo().mem.getHeapUsedPercent() < threshold
+                JvmProbe.getInstance().jvmInfo().mem.getHeapUsedPercent() < threshold()
                     ? Result.healthy()
-                    : Result.unhealthy(String.format("Memory percent is over the threshold of %d %%", threshold))
+                    : Result.unhealthy(String.format("Memory percent is over the threshold of %d %%", threshold()))
             );
         } catch (Exception ex) {
             return CompletableFuture.completedFuture(Result.unhealthy(ex));
         }
+    }
+
+    private int threshold() {
+        return configuration.getProperty("services.health.threshold.memory", Integer.class, 80);
     }
 }

--- a/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/spring/UpgraderConfiguration.java
+++ b/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/spring/UpgraderConfiguration.java
@@ -16,11 +16,13 @@
 package io.gravitee.node.services.upgrader.spring;
 
 import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.node.api.upgrader.UpgraderRepository;
 import io.gravitee.node.services.upgrader.UpgraderServiceImpl;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
@@ -30,8 +32,11 @@ import org.springframework.context.annotation.Configuration;
 public class UpgraderConfiguration {
 
     @Bean
-    public UpgraderServiceImpl upgraderService() {
-        return new UpgraderServiceImpl();
+    public UpgraderServiceImpl upgraderService(
+        io.gravitee.node.api.configuration.Configuration configuration,
+        @Lazy UpgraderRepository upgraderRepository
+    ) {
+        return new UpgraderServiceImpl(configuration, upgraderRepository);
     }
 
     public static List<Class<? extends LifecycleComponent>> getComponents() {

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
                 <artifactId>gravitee-node-secrets-plugin-handler</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-notifier</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!-- Gravitee.io -->
             <dependency>
                 <groupId>io.gravitee.common</groupId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-299

**Description**

This PR defers most of the `@Value` and some bean instantiations in order to make them eligible for secret injection (waiting for a proper global solution).

**Additional context**

This mainly covers the server bootstraps that are susceptible to being configured using secrets such as keystore passwords.
- Jetty server
- Vertx HTTP/TCP server
- Management Server
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.6.1-archi-299-defer-resolve-values-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.6.1-archi-299-defer-resolve-values-SNAPSHOT/gravitee-node-4.6.1-archi-299-defer-resolve-values-SNAPSHOT.zip)
  <!-- Version placeholder end -->
