### PR TITLE
feat: add queue on ClusterManager

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/ClusterManager.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/ClusterManager.java
@@ -16,6 +16,7 @@
 package io.gravitee.node.api.cluster;
 
 import io.gravitee.common.service.Service;
+import io.gravitee.node.api.cluster.messaging.Queue;
 import io.gravitee.node.api.cluster.messaging.Topic;
 import java.util.Set;
 
@@ -57,4 +58,12 @@ public interface ClusterManager extends Service<ClusterManager> {
      * @param <T> the type of content that will be published or consumed.
      */
     <T> Topic<T> topic(final String name);
+
+    /**
+     * Return a {@link Queue <T>} used to send or consume messages.
+     * @param name the name used to retrieve the queue
+     * @return a {@link Queue<T>}
+     * @param <T> the type of content that will be published or consumed.
+     */
+    <T> Queue<T> queue(final String name);
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/messaging/Message.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/messaging/Message.java
@@ -29,8 +29,14 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 public class Message<T> {
 
+    /**
+     * Could be either a topic or queue name
+     */
     @NonNull
-    private final String topic;
+    private final String destination;
 
+    /**
+     * Actual message content
+     */
     private final T content;
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/messaging/Queue.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/messaging/Queue.java
@@ -16,25 +16,26 @@
 package io.gravitee.node.api.cluster.messaging;
 
 /**
- * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface Topic<T> {
+public interface Queue<T> {
     /**
-     * Publish a new event on the current topic
-     * @param event the event to publish
+     * Publish a new message on the current queue
+     * @param item the item to send
+     * @throws IllegalStateException – if the element cannot be added at this time due to capacity restrictions
      */
-    void publish(T event);
+    void add(T item);
 
     /**
-     * Add a new listener on this topic. The given listener will be notified on any new message on the topic.
+     * Add a new listener on this queue. The given listener will be notified on any new message on the queue.
      * @param messageListener the listener to notify
      * @return the subscription identifier. Could be used to remove this listener.
      */
     String addMessageListener(final MessageListener<T> messageListener);
 
     /**
-     * Remove a listener on this topic from its subscription id.
+     * Remove a listener on this queue from its subscription id.
      * @param subscriptionId the subscription id used to remove the listener
      * @return <code>true</code> if any listener has been removed, <code>false</code> otherwise.
      */

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastClusterManager.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastClusterManager.java
@@ -17,13 +17,16 @@ package io.gravitee.node.plugin.cluster.hazelcast;
 
 import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.cluster.MembershipListener;
+import com.hazelcast.collection.IQueue;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.topic.ITopic;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.node.api.cluster.Member;
 import io.gravitee.node.api.cluster.MemberListener;
+import io.gravitee.node.api.cluster.messaging.Queue;
 import io.gravitee.node.api.cluster.messaging.Topic;
+import io.gravitee.node.plugin.cluster.hazelcast.messaging.HazelcastQueue;
 import io.gravitee.node.plugin.cluster.hazelcast.messaging.HazelcastTopic;
 import java.util.HashSet;
 import java.util.Set;
@@ -90,6 +93,12 @@ public class HazelcastClusterManager extends AbstractService<ClusterManager> imp
     public <T> Topic<T> topic(final String name) {
         ITopic<T> iTopic = hazelcastInstance.getTopic(name);
         return new HazelcastTopic<>(iTopic);
+    }
+
+    @Override
+    public <T> Queue<T> queue(final String name) {
+        IQueue<T> iQueue = hazelcastInstance.getQueue(name);
+        return new HazelcastQueue<>(iQueue);
     }
 
     @Override

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/messaging/HazelcastQueue.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/messaging/HazelcastQueue.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugin.cluster.hazelcast.messaging;
+
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import io.gravitee.node.api.cluster.messaging.Message;
+import io.gravitee.node.api.cluster.messaging.MessageListener;
+import io.gravitee.node.api.cluster.messaging.Queue;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HazelcastQueue<T> implements Queue<T> {
+
+    private final IQueue<T> iQueue;
+    private final Map<String, QueuePollingThread<T>> queuePollingThreads = new ConcurrentHashMap<>();
+
+    public HazelcastQueue(IQueue<T> iQueue) {
+        this.iQueue = iQueue;
+    }
+
+    @Override
+    public void add(T item) {
+        iQueue.add(item);
+    }
+
+    @Override
+    public String addMessageListener(final MessageListener<T> messageListener) {
+        String subscriptionId = io.gravitee.common.utils.UUID.random().toString();
+        QueuePollingThread<T> queuePollingThread = new QueuePollingThread<>(iQueue, messageListener);
+        queuePollingThread.start();
+        queuePollingThreads.put(subscriptionId, queuePollingThread);
+        return subscriptionId;
+    }
+
+    @Override
+    public boolean removeMessageListener(final String subscriptionId) {
+        QueuePollingThread<T> queuePollingThread = queuePollingThreads.remove(subscriptionId);
+        if (queuePollingThread != null) {
+            queuePollingThread.terminate();
+        }
+        return true;
+    }
+
+    @RequiredArgsConstructor
+    @Slf4j
+    public static class QueuePollingThread<T> extends Thread {
+
+        private final IQueue<T> queue;
+        private final MessageListener<T> messageListener;
+        private volatile boolean running;
+
+        @Override
+        public void run() {
+            running = true;
+
+            while (running) {
+                try {
+                    final T item = queue.poll(100, TimeUnit.MILLISECONDS);
+
+                    if (item != null) {
+                        messageListener.onMessage(new Message<>(queue.getName(), item));
+                    }
+                } catch (HazelcastInstanceNotActiveException e) {
+                    log.info("Hazelcast is not active, stop polling queue '{}'.", queue.getName());
+                    terminate();
+                } catch (Exception e) {
+                    log.warn("Polling hazelcast queue encountered an error.", e);
+                }
+            }
+        }
+
+        public void terminate() {
+            this.running = false;
+        }
+    }
+}

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
@@ -50,6 +50,11 @@
             <version>${guava.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/StandaloneClusterManager.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/StandaloneClusterManager.java
@@ -19,8 +19,10 @@ import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.node.api.cluster.Member;
 import io.gravitee.node.api.cluster.MemberListener;
+import io.gravitee.node.api.cluster.messaging.Queue;
 import io.gravitee.node.api.cluster.messaging.Topic;
 import io.gravitee.node.plugin.cluster.standalone.messaging.StandaloneMessageCodec;
+import io.gravitee.node.plugin.cluster.standalone.messaging.StandaloneQueue;
 import io.gravitee.node.plugin.cluster.standalone.messaging.StandaloneTopic;
 import io.vertx.core.Vertx;
 import java.util.Map;
@@ -37,6 +39,7 @@ public class StandaloneClusterManager extends AbstractService<ClusterManager> im
 
     private static final Member LOCAL_MEMBER = new StandaloneMember();
     private final Map<String, Topic<?>> topicsByName = new ConcurrentHashMap<>();
+    private final Map<String, Queue<?>> queuesByName = new ConcurrentHashMap<>();
     private final Vertx vertx;
 
     @Override
@@ -73,5 +76,10 @@ public class StandaloneClusterManager extends AbstractService<ClusterManager> im
     @Override
     public <T> Topic<T> topic(final String name) {
         return (Topic<T>) topicsByName.computeIfAbsent(name, key -> new StandaloneTopic<>(vertx, name));
+    }
+
+    @Override
+    public <T> Queue<T> queue(final String name) {
+        return (Queue<T>) queuesByName.computeIfAbsent(name, key -> new StandaloneQueue<>(vertx, name));
     }
 }

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/messaging/StandaloneQueue.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/messaging/StandaloneQueue.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugin.cluster.standalone.messaging;
+
+import io.gravitee.node.api.cluster.messaging.Message;
+import io.gravitee.node.api.cluster.messaging.MessageListener;
+import io.gravitee.node.api.cluster.messaging.Queue;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.MessageConsumer;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class StandaloneQueue<T> implements Queue<T> {
+
+    private final Map<String, MessageConsumer<T>> consumerMap = new ConcurrentHashMap<>();
+    private final Vertx vertx;
+    private final String queueName;
+    private final DeliveryOptions deliveryOptions;
+
+    public StandaloneQueue(final Vertx vertx, final String queueName) {
+        this.vertx = vertx;
+        this.queueName = queueName;
+        this.deliveryOptions = new DeliveryOptions().setCodecName(StandaloneMessageCodec.STANDALONE_CODEC_NAME);
+    }
+
+    @Override
+    public void add(T item) {
+        vertx.eventBus().send(queueName, item, deliveryOptions);
+    }
+
+    @Override
+    public String addMessageListener(final MessageListener<T> messageListener) {
+        String subscriptionId = io.gravitee.common.utils.UUID.random().toString();
+
+        MessageConsumer<T> vertxConsumer = vertx
+            .eventBus()
+            .<T>localConsumer(queueName)
+            .handler(event ->
+                vertx.executeBlocking(
+                    (Handler<Promise<Void>>) promise -> {
+                        messageListener.onMessage(new Message<>(queueName, event.body()));
+                        promise.handle(null);
+                    }
+                )
+            );
+        consumerMap.put(subscriptionId, vertxConsumer);
+
+        return subscriptionId;
+    }
+
+    @Override
+    public boolean removeMessageListener(final String subscriptionId) {
+        if (consumerMap.containsKey(subscriptionId)) {
+            return consumerMap.get(subscriptionId).unregister().onSuccess(event -> consumerMap.remove(subscriptionId)).succeeded();
+        }
+        return false;
+    }
+}

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/test/java/io/gravitee/node/plugin/cluster/standalone/messaging/StandaloneQueueTest.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/test/java/io/gravitee/node/plugin/cluster/standalone/messaging/StandaloneQueueTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;        http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.
+ */
+
+package io.gravitee.node.plugin.cluster.standalone.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StandaloneQueueTest {
+
+    public static final String QUEUE_NAME = "queueName";
+    private StandaloneQueue<String> cut;
+
+    @BeforeEach
+    public void beforeEach(Vertx vertx) {
+        vertx.eventBus().registerCodec(new StandaloneMessageCodec());
+        cut = new StandaloneQueue<>(vertx, QUEUE_NAME);
+    }
+
+    @Test
+    void should_add_item_to_queue(Vertx vertx, VertxTestContext testContext) {
+        Checkpoint itemReceived = testContext.checkpoint();
+        vertx
+            .eventBus()
+            .<String>localConsumer(QUEUE_NAME)
+            .handler(event ->
+                vertx.executeBlocking(
+                    (Handler<Promise<Void>>) promise -> {
+                        itemReceived.flag();
+                        assertThat(event.body()).isEqualTo("message");
+                        promise.handle(null);
+                    }
+                )
+            );
+
+        cut.add("message");
+    }
+
+    @Test
+    void should_receive_item_only_once(VertxTestContext testContext) {
+        Checkpoint oneListenerOnly = testContext.checkpoint();
+        cut.addMessageListener(message -> oneListenerOnly.flag());
+        cut.addMessageListener(message -> oneListenerOnly.flag());
+        cut.add("message");
+    }
+}

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/test/java/io/gravitee/node/plugin/cluster/standalone/messaging/StandaloneTopicTest.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/test/java/io/gravitee/node/plugin/cluster/standalone/messaging/StandaloneTopicTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;        http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.
+ */
+
+package io.gravitee.node.plugin.cluster.standalone.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StandaloneTopicTest {
+
+    public static final String TOPIC_NAME = "topicName";
+    private StandaloneTopic<String> cut;
+
+    @BeforeEach
+    public void beforeEach(Vertx vertx) {
+        vertx.eventBus().registerCodec(new StandaloneMessageCodec());
+        cut = new StandaloneTopic<>(vertx, TOPIC_NAME);
+    }
+
+    @Test
+    void should_publish_event_to_topic(Vertx vertx, VertxTestContext testContext) {
+        Checkpoint itemReceived = testContext.checkpoint();
+        vertx
+            .eventBus()
+            .<String>localConsumer(TOPIC_NAME)
+            .handler(event ->
+                vertx.executeBlocking(
+                    (Handler<Promise<Void>>) promise -> {
+                        itemReceived.flag();
+                        assertThat(event.body()).isEqualTo("message");
+                        promise.handle(null);
+                    }
+                )
+            );
+
+        cut.publish("message");
+    }
+
+    @Test
+    void should_receive_event_on_all_listeners(VertxTestContext testContext) {
+        Checkpoint allListeners = testContext.checkpoint(2);
+        cut.addMessageListener(message -> allListeners.flag());
+        cut.addMessageListener(message -> allListeners.flag());
+        cut.publish("message");
+    }
+}


### PR DESCRIPTION

**Description**

Add queue on cluster manager with implementation for standalone or hazelcast cluster.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.7.0-integration-foundation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.7.0-integration-foundation-SNAPSHOT/gravitee-node-4.7.0-integration-foundation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
