### PR TITLE
feat: improve Cache interface

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/Cache.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/Cache.java
@@ -18,6 +18,8 @@ package io.gravitee.node.api.cache;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -32,6 +34,8 @@ public interface Cache<K, V> {
 
     Collection<V> values();
 
+    boolean containsKey(final K key);
+
     V get(final K key);
 
     V put(final K key, final V value);
@@ -39,6 +43,12 @@ public interface Cache<K, V> {
     V put(final K key, final V value, final long ttl, final TimeUnit ttlUnit);
 
     void putAll(final Map<? extends K, ? extends V> m);
+
+    V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction);
+
+    V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction);
+
+    V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction);
 
     V evict(final K key);
 

--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
@@ -24,18 +24,19 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import lombok.AllArgsConstructor;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class HazelcastCache<K, V> implements Cache<K, V> {
 
-    private IMap<K, V> cache;
-
-    private long timeToLiveInMs = -1;
+    private final IMap<K, V> cache;
+    private final long timeToLiveInMs;
 
     @Override
     public String getName() {
@@ -55,6 +56,11 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     @Override
     public Collection<V> values() {
         return this.cache.values();
+    }
+
+    @Override
+    public boolean containsKey(final K key) {
+        return this.cache.containsKey(key);
     }
 
     @Override
@@ -83,6 +89,21 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
         this.cache.putAll(m);
+    }
+
+    @Override
+    public V computeIfAbsent(final K key, final Function<? super K, ? extends V> mappingFunction) {
+        return this.cache.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public V computeIfPresent(final K key, final BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return this.cache.computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public V compute(final K key, final BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return this.cache.compute(key, remappingFunction);
     }
 
     @Override
@@ -119,12 +140,12 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
                                 case EXPIRED:
                                     cacheListener.onEntryExpired(event.getKey(), event.getValue());
                                     break;
-                                default:
                                 case EVICT_ALL:
                                 case CLEAR_ALL:
                                 case MERGED:
                                 case INVALIDATION:
                                 case LOADED:
+                                default:
                                     break;
                             }
                         }


### PR DESCRIPTION
**Description**

  - implement new methods on InMemory and Hazelcast cache implementation

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.8.0-improve-cache-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.8.0-improve-cache-api-SNAPSHOT/gravitee-node-4.8.0-improve-cache-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
