### PR TITLE
fix: update pem registry logic

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/certificate/KeyStoreLoader.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/certificate/KeyStoreLoader.java
@@ -26,8 +26,7 @@ public interface KeyStoreLoader {
     String CERTIFICATE_FORMAT_PEM = "PEM";
     String CERTIFICATE_FORMAT_PKCS12 = "PKCS12";
     String CERTIFICATE_FORMAT_SELF_SIGNED = "SELF-SIGNED";
-    String CERTIFICATE_FORMAT_PEM_REGISTRY = "PEM-REGISTRY";
-    String GRAVITEEIO_PEM_REGISTRY = "graviteeio-pem-registry";
+    String CERTIFICATE_FORMAT_PEM_REGISTRY = "KUBERNETES-PEM-REGISTRY";
 
     void start();
 

--- a/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesKeyStoreLoaderFactory.java
+++ b/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesKeyStoreLoaderFactory.java
@@ -33,7 +33,11 @@ public class KubernetesKeyStoreLoaderFactory implements KeyStoreLoaderFactory {
     }
 
     public boolean canHandle(KeyStoreLoaderOptions options) {
-        return (KubernetesConfigMapKeyStoreLoader.canHandle(options) || KubernetesSecretKeyStoreLoader.canHandle(options));
+        return (
+            KubernetesConfigMapKeyStoreLoader.canHandle(options) ||
+            KubernetesSecretKeyStoreLoader.canHandle(options) ||
+            KubernetesPemRegistryKeyStoreLoader.canHandle(options)
+        );
     }
 
     public KeyStoreLoader create(KeyStoreLoaderOptions options) {
@@ -41,6 +45,8 @@ public class KubernetesKeyStoreLoaderFactory implements KeyStoreLoaderFactory {
             return new KubernetesConfigMapKeyStoreLoader(options, client);
         } else if (KubernetesSecretKeyStoreLoader.canHandle(options)) {
             return new KubernetesSecretKeyStoreLoader(options, client);
+        } else if (KubernetesPemRegistryKeyStoreLoader.canHandle(options)) {
+            return new KubernetesPemRegistryKeyStoreLoader(options, client);
         }
 
         throw new IllegalArgumentException("Cannot found appropriate KubernetesKeyStoreLoaderFactory.");

--- a/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesPemRegistryKeyStoreLoader.java
+++ b/gravitee-node-kubernetes/src/main/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesPemRegistryKeyStoreLoader.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.kubernetes.keystoreloader;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.util.KeyStoreUtils;
+import io.gravitee.kubernetes.client.KubernetesClient;
+import io.gravitee.kubernetes.client.api.LabelSelector;
+import io.gravitee.kubernetes.client.api.ResourceQuery;
+import io.gravitee.kubernetes.client.api.WatchQuery;
+import io.gravitee.kubernetes.client.config.KubernetesConfig;
+import io.gravitee.kubernetes.client.model.v1.ConfigMap;
+import io.gravitee.kubernetes.client.model.v1.ConfigMapList;
+import io.gravitee.kubernetes.client.model.v1.Event;
+import io.gravitee.kubernetes.client.model.v1.Secret;
+import io.gravitee.node.api.certificate.KeyStoreLoader;
+import io.gravitee.node.api.certificate.KeyStoreLoaderOptions;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.security.KeyStore;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class KubernetesPemRegistryKeyStoreLoader extends AbstractKubernetesKeyStoreLoader<ConfigMap> {
+
+    public static final String GRAVITEEIO_PEM_REGISTRY_LABEL = "gravitee.io/component";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public KubernetesPemRegistryKeyStoreLoader(KeyStoreLoaderOptions options, KubernetesClient kubernetesClient) {
+        super(options, kubernetesClient);
+        prepareLocations();
+    }
+
+    private void prepareLocations() {
+        if (options.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM_REGISTRY)) {
+            this.resources.put(CERTIFICATE_FORMAT_PEM_REGISTRY, null);
+        }
+    }
+
+    public static boolean canHandle(KeyStoreLoaderOptions options) {
+        return options.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM_REGISTRY);
+    }
+
+    @Override
+    protected Completable init() {
+        return Flowable
+            .fromIterable(resources.keySet())
+            .flatMapCompletable(location -> {
+                if (CERTIFICATE_FORMAT_PEM_REGISTRY.equals(location)) {
+                    String currentNamespace = KubernetesConfig.getInstance().getCurrentNamespace();
+                    return this.kubernetesClient.get(
+                            ResourceQuery
+                                .configMaps(currentNamespace)
+                                .labelSelector(
+                                    LabelSelector.equals(GRAVITEEIO_PEM_REGISTRY_LABEL, CERTIFICATE_FORMAT_PEM_REGISTRY.toLowerCase())
+                                )
+                                .build()
+                        )
+                        .flatMapCompletable(configMapList -> {
+                            List<ConfigMap> items = configMapList.getItems();
+                            if (items.isEmpty()) {
+                                return Completable.error(new RuntimeException("No pem registry found in the current namespace"));
+                            } else if (items.size() > 1) {
+                                return Completable.error(new RuntimeException("multiple pem registry is not supported"));
+                            } else {
+                                String newLocation = String.format(
+                                    "/%s/configmaps/%s",
+                                    currentNamespace,
+                                    items.get(0).getMetadata().getName()
+                                );
+                                this.resources.put(newLocation, ResourceQuery.<ConfigMap>from(newLocation).build());
+
+                                return this.loadKeyStore(items.get(0));
+                            }
+                        })
+                        .doOnComplete(() -> resources.remove(CERTIFICATE_FORMAT_PEM_REGISTRY));
+                }
+
+                return Completable.error(new RuntimeException(String.format("unsupported keystore locations %s", location)));
+            })
+            .andThen(Completable.fromRunnable(this::refreshKeyStoreBundle));
+    }
+
+    @Override
+    protected Flowable<ConfigMap> watch() {
+        return Flowable
+            .fromIterable(resources.keySet())
+            .flatMap(location ->
+                kubernetesClient
+                    .watch(WatchQuery.<ConfigMap>from(location).build())
+                    .observeOn(Schedulers.computation())
+                    .repeat()
+                    .retryWhen(errors -> errors.delay(RETRY_DELAY_MILLIS, TimeUnit.MILLISECONDS))
+            )
+            .filter(event -> event.getType().equalsIgnoreCase("MODIFIED"))
+            .map(Event::getObject);
+    }
+
+    @Override
+    protected Completable loadKeyStore(ConfigMap configMap) {
+        if (options.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM_REGISTRY)) {
+            if (
+                configMap.getMetadata().getLabels() != null &&
+                CERTIFICATE_FORMAT_PEM_REGISTRY.equalsIgnoreCase(configMap.getMetadata().getLabels().get(GRAVITEEIO_PEM_REGISTRY_LABEL)) &&
+                configMap.getData() != null
+            ) {
+                return generateKeystoreFromPemRegistry(configMap);
+            } else {
+                // make sure there is no keys left from the past
+                keyStoresByLocation.put(GRAVITEEIO_PEM_REGISTRY_LABEL, initKeyStore());
+                return Completable.complete();
+            }
+        }
+
+        return Completable.error(new RuntimeException(String.format("unsupported keystore type %s", options.getKeyStoreType())));
+    }
+
+    private Completable generateKeystoreFromPemRegistry(ConfigMap configMap) {
+        return Flowable
+            .fromIterable(configMap.getData().values())
+            .map(objectMapper::readTree)
+            .filter(JsonNode::isArray)
+            .flatMap(Flowable::fromIterable)
+            .map(JsonNode::asText)
+            .distinct()
+            .filter(StringUtils::hasLength)
+            .flatMapMaybe(reference -> {
+                String[] namespaceName = reference.split("/");
+                if (namespaceName.length != 2) {
+                    return Maybe.error(new IllegalArgumentException("Wrong or missing namespace or name of the TLS Secret"));
+                }
+                return kubernetesClient.get(ResourceQuery.secret(namespaceName[0], namespaceName[1]).build()).map(this::secretToKeyStore);
+            })
+            .toList()
+            .map(keyStoreList -> KeyStoreUtils.merge(keyStoreList, options.getKeyStorePassword()))
+            .doOnSuccess(keyStore -> keyStoresByLocation.put(GRAVITEEIO_PEM_REGISTRY_LABEL, keyStore))
+            .ignoreElement();
+    }
+
+    private KeyStore initKeyStore() {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(KeyStoreUtils.DEFAULT_KEYSTORE_TYPE);
+            keyStore.load(null, KeyStoreUtils.passwordToCharArray(options.getKeyStorePassword()));
+            return keyStore;
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Unable to reset the %s keystore", GRAVITEEIO_PEM_REGISTRY_LABEL), e);
+        }
+    }
+
+    private KeyStore secretToKeyStore(Secret secret) {
+        final Map<String, String> data = secret.getData();
+
+        if (data == null || data.isEmpty()) {
+            throw new RuntimeException(String.format("No data has been found in the secret %s", secret.getMetadata().getName()));
+        }
+
+        return KeyStoreUtils.initFromPem(
+            new String(Base64.getDecoder().decode(data.get(KubernetesSecretKeyStoreLoader.KUBERNETES_TLS_CRT))),
+            new String(Base64.getDecoder().decode(data.get(KubernetesSecretKeyStoreLoader.KUBERNETES_TLS_KEY))),
+            options.getKeyStorePassword(),
+            secret.getMetadata().getName()
+        );
+    }
+}

--- a/gravitee-node-kubernetes/src/test/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesConfigMapKeyStoreLoaderTest.java
+++ b/gravitee-node-kubernetes/src/test/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesConfigMapKeyStoreLoaderTest.java
@@ -15,29 +15,28 @@
  */
 package io.gravitee.node.kubernetes.keystoreloader;
 
-import static io.gravitee.node.api.certificate.KeyStoreLoader.GRAVITEEIO_PEM_REGISTRY;
+import static io.gravitee.node.kubernetes.keystoreloader.KubernetesPemRegistryKeyStoreLoader.GRAVITEEIO_PEM_REGISTRY_LABEL;
 import static io.gravitee.node.kubernetes.keystoreloader.KubernetesSecretKeyStoreLoader.*;
 import static io.gravitee.node.kubernetes.keystoreloader.KubernetesSecretKeyStoreLoader.KUBERNETES_TLS_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import io.gravitee.kubernetes.client.KubernetesClient;
+import io.gravitee.kubernetes.client.api.LabelSelector;
 import io.gravitee.kubernetes.client.api.ResourceQuery;
-import io.gravitee.kubernetes.client.model.v1.ConfigMap;
-import io.gravitee.kubernetes.client.model.v1.ObjectMeta;
-import io.gravitee.kubernetes.client.model.v1.Secret;
+import io.gravitee.kubernetes.client.config.KubernetesConfig;
+import io.gravitee.kubernetes.client.model.v1.*;
 import io.gravitee.node.api.certificate.KeyStoreBundle;
 import io.gravitee.node.api.certificate.KeyStoreLoader;
 import io.gravitee.node.api.certificate.KeyStoreLoaderOptions;
 import io.reactivex.rxjava3.core.Maybe;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.KeyStoreException;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -131,78 +130,6 @@ public class KubernetesConfigMapKeyStoreLoaderTest {
 
         assertNotNull(keyStoreBundle);
         assertEquals(1, keyStoreBundle.getKeyStore().size());
-    }
-
-    @Test
-    public void shouldLoadGraviteePemRegistry() throws IOException, KeyStoreException {
-        final KeyStoreLoaderOptions options = KeyStoreLoaderOptions
-            .builder()
-            .withKeyStoreType(KeyStoreLoader.CERTIFICATE_FORMAT_PEM_REGISTRY)
-            .withKubernetesLocations(Collections.singletonList("/gio/configmaps/" + KeyStoreLoader.GRAVITEEIO_PEM_REGISTRY))
-            .withKeyStorePassword("secret")
-            .withWatch(false)
-            .build();
-
-        cut = new KubernetesConfigMapKeyStoreLoader(options, kubernetesClient);
-
-        final ConfigMap pemRegistry = new ConfigMap();
-
-        final HashMap<String, String> pemRegistryData = new HashMap<>();
-        pemRegistryData.put("localhost", "my-tls-secret1");
-        pemRegistryData.put("localhost2", "my-tls-secret2");
-        pemRegistry.setData(pemRegistryData);
-
-        final ObjectMeta pemRegistryMetadata = new ObjectMeta();
-        pemRegistryMetadata.setName(KeyStoreLoader.GRAVITEEIO_PEM_REGISTRY);
-        pemRegistryMetadata.setNamespace("gio");
-        pemRegistryMetadata.setAnnotations(Collections.singletonMap(GRAVITEEIO_PEM_REGISTRY, "true"));
-        pemRegistryMetadata.setUid("/namespaces/gio/configmaps" + KeyStoreLoader.GRAVITEEIO_PEM_REGISTRY);
-        pemRegistry.setMetadata(pemRegistryMetadata);
-
-        final Secret secret1 = new Secret();
-        secret1.setType(KUBERNETES_TLS_SECRET);
-
-        final HashMap<String, String> data1 = new HashMap<>();
-        data1.put(KUBERNETES_TLS_CRT, readContent("localhost.cer"));
-        data1.put(KUBERNETES_TLS_KEY, readContent("localhost.key"));
-        secret1.setData(data1);
-
-        final ObjectMeta metadata1 = new ObjectMeta();
-        metadata1.setName("my-tls-secret1");
-        metadata1.setUid("/namespaces/gio/secrets/my-tls-secret");
-        secret1.setMetadata(metadata1);
-
-        final Secret secret2 = new Secret();
-        secret2.setType(KUBERNETES_TLS_SECRET);
-
-        final HashMap<String, String> data2 = new HashMap<>();
-        data2.put(KUBERNETES_TLS_CRT, readContent("localhost2.cer"));
-        data2.put(KUBERNETES_TLS_KEY, readContent("localhost2.key"));
-        secret2.setData(data2);
-
-        final ObjectMeta metadata2 = new ObjectMeta();
-        metadata2.setName("my-tls-secret2");
-        metadata2.setUid("/namespaces/gio/secrets/my-tls-secret2");
-        secret2.setMetadata(metadata2);
-
-        Mockito
-            .when(kubernetesClient.get(ResourceQuery.<ConfigMap>from("/gio/configmaps/" + KeyStoreLoader.GRAVITEEIO_PEM_REGISTRY).build()))
-            .thenReturn((Maybe.just(pemRegistry)));
-        Mockito
-            .when(kubernetesClient.get(ResourceQuery.<Secret>from("/gio/secrets/my-tls-secret1").build()))
-            .thenReturn(Maybe.just(secret1));
-        Mockito
-            .when(kubernetesClient.get(ResourceQuery.<Secret>from("/gio/secrets/my-tls-secret2").build()))
-            .thenReturn(Maybe.just(secret2));
-
-        AtomicReference<KeyStoreBundle> bundleRef = new AtomicReference<>(null);
-        cut.addListener(bundleRef::set);
-        cut.start();
-
-        final KeyStoreBundle keyStoreBundle = bundleRef.get();
-
-        assertNotNull(keyStoreBundle);
-        assertEquals(2, keyStoreBundle.getKeyStore().size());
     }
 
     private String readContent(String resource) throws IOException {

--- a/gravitee-node-kubernetes/src/test/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesPemRegistryKeyStoreLoaderTest.java
+++ b/gravitee-node-kubernetes/src/test/java/io/gravitee/node/kubernetes/keystoreloader/KubernetesPemRegistryKeyStoreLoaderTest.java
@@ -1,0 +1,127 @@
+package io.gravitee.node.kubernetes.keystoreloader;
+
+import static io.gravitee.node.api.certificate.KeyStoreLoader.CERTIFICATE_FORMAT_PEM_REGISTRY;
+import static io.gravitee.node.kubernetes.keystoreloader.KubernetesPemRegistryKeyStoreLoader.GRAVITEEIO_PEM_REGISTRY_LABEL;
+import static io.gravitee.node.kubernetes.keystoreloader.KubernetesSecretKeyStoreLoader.*;
+import static io.gravitee.node.kubernetes.keystoreloader.KubernetesSecretKeyStoreLoader.KUBERNETES_TLS_KEY;
+import static org.junit.Assert.*;
+
+import io.gravitee.kubernetes.client.KubernetesClient;
+import io.gravitee.kubernetes.client.api.LabelSelector;
+import io.gravitee.kubernetes.client.api.ResourceQuery;
+import io.gravitee.kubernetes.client.config.KubernetesConfig;
+import io.gravitee.kubernetes.client.model.v1.*;
+import io.gravitee.node.api.certificate.KeyStoreBundle;
+import io.gravitee.node.api.certificate.KeyStoreLoader;
+import io.gravitee.node.api.certificate.KeyStoreLoaderOptions;
+import io.reactivex.rxjava3.core.Maybe;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.KeyStoreException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesPemRegistryKeyStoreLoaderTest {
+
+    @Mock
+    private KubernetesClient kubernetesClient;
+
+    private KubernetesPemRegistryKeyStoreLoader cut;
+
+    @Test
+    public void shouldLoadGraviteePemRegistry() throws IOException, KeyStoreException {
+        KubernetesConfig.getInstance().setCurrentNamespace("test");
+        final ConfigMap pemRegistry = new ConfigMap();
+
+        final HashMap<String, String> pemRegistryData = new HashMap<>();
+        pemRegistryData.put("site1", "[\"gio/my-tls-secret1\",\"gio/my-tls-secret2\"]");
+        pemRegistry.setData(pemRegistryData);
+
+        final ObjectMeta pemRegistryMetadata = new ObjectMeta();
+        pemRegistryMetadata.setName(KeyStoreLoader.CERTIFICATE_FORMAT_PEM_REGISTRY);
+        pemRegistryMetadata.setNamespace("gio");
+        pemRegistryMetadata.setLabels(Collections.singletonMap(GRAVITEEIO_PEM_REGISTRY_LABEL, CERTIFICATE_FORMAT_PEM_REGISTRY));
+        pemRegistryMetadata.setUid("/namespaces/gio/configmaps/" + GRAVITEEIO_PEM_REGISTRY_LABEL);
+        pemRegistry.setMetadata(pemRegistryMetadata);
+
+        final Secret secret1 = new Secret();
+        secret1.setType(KUBERNETES_TLS_SECRET);
+
+        final HashMap<String, String> data1 = new HashMap<>();
+        data1.put(KUBERNETES_TLS_CRT, readContent("localhost.cer"));
+        data1.put(KUBERNETES_TLS_KEY, readContent("localhost.key"));
+        secret1.setData(data1);
+
+        final ObjectMeta metadata1 = new ObjectMeta();
+        metadata1.setName("my-tls-secret1");
+        metadata1.setUid("/namespaces/gio/secrets/my-tls-secret");
+        secret1.setMetadata(metadata1);
+
+        final Secret secret2 = new Secret();
+        secret2.setType(KUBERNETES_TLS_SECRET);
+
+        final HashMap<String, String> data2 = new HashMap<>();
+        data2.put(KUBERNETES_TLS_CRT, readContent("localhost2.cer"));
+        data2.put(KUBERNETES_TLS_KEY, readContent("localhost2.key"));
+        secret2.setData(data2);
+
+        final ObjectMeta metadata2 = new ObjectMeta();
+        metadata2.setName("my-tls-secret2");
+        metadata2.setUid("/namespaces/gio/secrets/my-tls-secret2");
+        secret2.setMetadata(metadata2);
+
+        Mockito
+            .when(
+                kubernetesClient.get(
+                    ResourceQuery
+                        .configMaps("test")
+                        .labelSelector(LabelSelector.equals(GRAVITEEIO_PEM_REGISTRY_LABEL, CERTIFICATE_FORMAT_PEM_REGISTRY))
+                        .build()
+                )
+            )
+            .thenReturn(Maybe.just(new ConfigMapList("v1", List.of(pemRegistry), "v1", new ListMeta("1", 1L, "1234", "/selflink"))));
+        Mockito
+            .when(kubernetesClient.get(ResourceQuery.<Secret>from("/gio/secrets/my-tls-secret1").build()))
+            .thenReturn(Maybe.just(secret1));
+        Mockito
+            .when(kubernetesClient.get(ResourceQuery.<Secret>from("/gio/secrets/my-tls-secret2").build()))
+            .thenReturn(Maybe.just(secret2));
+
+        final KeyStoreLoaderOptions options = KeyStoreLoaderOptions
+            .builder()
+            .withKeyStoreType(KeyStoreLoader.CERTIFICATE_FORMAT_PEM_REGISTRY)
+            .withKeyStorePassword("secret")
+            .withWatch(false)
+            .build();
+
+        cut = new KubernetesPemRegistryKeyStoreLoader(options, kubernetesClient);
+
+        AtomicReference<KeyStoreBundle> bundleRef = new AtomicReference<>(null);
+        cut.addListener(bundleRef::set);
+        cut.start();
+
+        final KeyStoreBundle keyStoreBundle = bundleRef.get();
+
+        assertNotNull(keyStoreBundle);
+        assertEquals(2, keyStoreBundle.getKeyStore().size());
+    }
+
+    private String readContent(String resource) throws IOException {
+        return java.util.Base64
+            .getEncoder()
+            .encodeToString(Files.readAllBytes(new File(this.getClass().getResource("/keystores/" + resource).getPath()).toPath()));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-plugin.version>2.2.0</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
-        <gravitee-kubernetes.version>3.0.2</gravitee-kubernetes.version>
+        <gravitee-kubernetes.version>3.1.0</gravitee-kubernetes.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <hazelcast.version>5.2.3</hazelcast.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2969


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.1-pem-registry-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.0.1-pem-registry-master-SNAPSHOT/gravitee-node-5.0.1-pem-registry-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
