### PR TITLE
feat(license): add graphql rate limit policy feature

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -25,6 +25,7 @@ packs:
             - apim-policy-transform-avro-json
             - am-policy-mfa-challenge
             - am-policy-account-linking
+            - apim-policy-graphql-ratelimit
     enterprise-identity-provider:
         features:
             - am-idp-salesforce

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -240,6 +240,7 @@ class DefaultLicenseFactoryTest {
             "am-policy-account-linking",
             "am-resource-sfr",
             "gravitee-en-secretprovider-vault",
+            "apim-policy-graphql-ratelimit",
         };
         assertThat(license.getFeatures()).containsExactlyInAnyOrder(features);
 


### PR DESCRIPTION


**Issue**

https://gravitee.atlassian.net/browse/APIM-3495



<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.2.0-apim-3495-graphql-ratelimit-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.2.0-apim-3495-graphql-ratelimit-SNAPSHOT/gravitee-node-5.2.0-apim-3495-graphql-ratelimit-SNAPSHOT.zip)
  <!-- Version placeholder end -->
