### PR TITLE
fix: defer node bean instantiation

### DIFF
--- a/gravitee-node-container/src/main/java/io/gravitee/node/container/AbstractContainer.java
+++ b/gravitee-node-container/src/main/java/io/gravitee/node/container/AbstractContainer.java
@@ -33,13 +33,10 @@ public abstract class AbstractContainer extends AbstractService<Container> imple
     private static final String GRAVITEE_HOME_PROPERTY = "gravitee.home";
     private static final String GRAVITEE_CONFIGURATION_PROPERTY = "gravitee.conf";
 
-    protected final Class<? extends Node> nodeClass;
     protected boolean stopped = false;
     protected boolean initialized = false;
 
-    public AbstractContainer(Class<? extends Node> nodeClass) {
-        this.nodeClass = nodeClass;
-    }
+    public AbstractContainer() {}
 
     public abstract void initialize();
 

--- a/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/NodeContainerConfiguration.java
+++ b/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/NodeContainerConfiguration.java
@@ -58,13 +58,12 @@ public class NodeContainerConfiguration {
 
     @Bean
     public LicenseLoaderService licenseLoaderService(
-        Node node,
         Configuration configuration,
         LicenseFactory licenseFactory,
         LicenseManager licenseManager,
         ManagementEndpointManager managementEndpointManager
     ) {
-        return new LicenseLoaderService(node, configuration, licenseFactory, licenseManager, managementEndpointManager);
+        return new LicenseLoaderService(configuration, licenseFactory, licenseManager, managementEndpointManager);
     }
 
     @Bean

--- a/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/SpringBasedContainer.java
+++ b/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/SpringBasedContainer.java
@@ -39,6 +39,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
@@ -49,10 +50,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 public abstract class SpringBasedContainer extends AbstractContainer {
 
     private AnnotationConfigApplicationContext ctx;
-
-    protected SpringBasedContainer(Class<? extends Node> nodeClass) {
-        super(nodeClass);
-    }
 
     @Override
     public void initialize() {
@@ -140,7 +137,6 @@ public abstract class SpringBasedContainer extends AbstractContainer {
         bootstrapClasses.add(SecretServiceConfiguration.class);
         bootstrapClasses.add(NodeCertificatesConfiguration.class);
         bootstrapClasses.add(KubernetesClientConfiguration.class);
-        bootstrapClasses.add(nodeClass);
 
         // Bean registry post processor needs to be manually registered as it MUST be taken in account before spring context is refreshed.
         bootstrapClasses.add(BootPluginHandlerBeanRegistryPostProcessor.class);

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/LicenseLoaderService.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/LicenseLoaderService.java
@@ -47,7 +47,6 @@ public class LicenseLoaderService extends AbstractService<LicenseLoaderService> 
     static final String GRAVITEE_LICENSE_KEY = "license.key";
     static final String GRAVITEE_LICENSE_PROPERTY = "gravitee.license";
 
-    private final Node node;
     private final Configuration configuration;
     private final LicenseFactory licenseFactory;
     private final LicenseManager licenseManager;
@@ -207,11 +206,6 @@ public class LicenseLoaderService extends AbstractService<LicenseLoaderService> 
     }
 
     private void stopNode() {
-        try {
-            node.stop();
-        } catch (Exception e) {
-            log.warn("Fail to stop node", e);
-        }
         System.exit(0);
     }
 }


### PR DESCRIPTION
**Issue**

Linked to https://gravitee.atlassian.net/browse/ARCHI-297

**Description**

The `Node` bean is instantiated twice. The objective of this PR is to get rid of the `Node` bean for the bootstrap phase and only instantiate it with the beans of the application.
For that, the `DefaultLicenseService` no longer needs the `Node` bean. It was previously mandatory to stop the node when the expiration of the license is detected. It has been replaced with a simple `System.exit(0)` which triggers the stop of the node by executing the shutdown hooks of the JVM.
