### PR TITLE
fix(license): allow unknown plugins during validation

### DIFF
--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseManager.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseManager.java
@@ -116,9 +116,7 @@ public class DefaultLicenseManager extends AbstractService<LicenseManager> imple
     private void validatePluginFeature(License license, Set<ForbiddenFeature> errors, Plugin plugin) {
         final io.gravitee.plugin.core.api.Plugin registryPlugin = pluginRegistry.get(plugin.type(), plugin.id());
 
-        if (registryPlugin == null) {
-            errors.add(new ForbiddenFeature("unknown", plugin.id()));
-        } else if (!license.isFeatureEnabled(registryPlugin.manifest().feature())) {
+        if (Objects.nonNull(registryPlugin) && !license.isFeatureEnabled(registryPlugin.manifest().feature())) {
             errors.add(new ForbiddenFeature(registryPlugin.manifest().feature(), plugin.id()));
         }
     }

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseManagerTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseManagerTest.java
@@ -153,7 +153,7 @@ class DefaultLicenseManagerTest {
     }
 
     @Test
-    void should_throw_forbidden_feature_when_validate_plugin_features_with_unknown_plugin() {
+    void should_not_throw_error_on_unknown_plugin() throws Exception {
         mockPluginRegistry();
 
         final License license = mock(License.class);
@@ -167,14 +167,7 @@ class DefaultLicenseManagerTest {
 
         cut.registerOrganizationLicense("orgId", license);
 
-        final ForbiddenFeatureException exception = assertThrows(
-            ForbiddenFeatureException.class,
-            () -> cut.validatePluginFeatures("orgId", List.of(kafkaPlugin, mqtt5Plugin, unknownPlugin))
-        );
-
-        assertThat(exception.getMessage())
-            .isEqualTo("Plugin [other] cannot be loaded because the feature [unknown] is not allowed by the license.");
-        assertThat(exception.getFeatures()).contains(new LicenseManager.ForbiddenFeature("unknown", "other"));
+        assertDoesNotThrow(() -> cut.validatePluginFeatures("orgId", List.of(kafkaPlugin, mqtt5Plugin, unknownPlugin)));
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3879

**Description**

When there are unknown plugins, the validator should not throw an exception.

This is necessary for the fact that the plugins that may exist in Gateway are not detected in the rest-api, and vice versa. 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.5.2-apim-3879-allow-unknown-plugins-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.5.2-apim-3879-allow-unknown-plugins-SNAPSHOT/gravitee-node-5.5.2-apim-3879-allow-unknown-plugins-SNAPSHOT.zip)
  <!-- Version placeholder end -->
