### PR TITLE
feat(license): allow oss license to be scoped + add method to return …

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/license/LicenseFactory.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/license/LicenseFactory.java
@@ -37,4 +37,12 @@ public interface LicenseFactory {
      */
     License create(@Nonnull String referenceType, @Nonnull String referenceId, @Nonnull byte[] bytesLicense)
         throws InvalidLicenseException, MalformedLicenseException;
+
+    /**
+     * Create an OSS {@link License} for an organization
+     *
+     * @param referenceId the reference id the license is created for
+     * @return
+     */
+    License createOSSOrganization(@Nonnull String referenceId);
 }

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseFactory.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseFactory.java
@@ -64,6 +64,11 @@ public class DefaultLicenseFactory implements LicenseFactory {
         }
     }
 
+    @Override
+    public License createOSSOrganization(@Nonnull String referenceId) {
+        return new OSSLicense(referenceId, License.REFERENCE_TYPE_ORGANIZATION);
+    }
+
     private License create(String referenceType, String referenceId, License3J license) throws InvalidLicenseException {
         // First, verify the license is valid.
         license.verify();

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseManager.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseManager.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DefaultLicenseManager extends AbstractService<LicenseManager> implements LicenseManager {
 
-    public static final License OSS_LICENSE = new OSSLicense();
+    public static final License OSS_LICENSE = new OSSLicense(License.REFERENCE_ID_PLATFORM, License.REFERENCE_TYPE_PLATFORM);
 
     private static final long DAY_AS_LONG = 24 * 60 * 60 * 1000L;
 

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/OSSLicense.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/OSSLicense.java
@@ -14,18 +14,25 @@ import java.util.Set;
  */
 class OSSLicense implements License {
 
+    public OSSLicense(String referenceId, String referenceType) {
+        this.referenceId = referenceId;
+        this.referenceType = referenceType;
+    }
+
     private static final String TIER = "oss";
     private static final Map<String, Object> ATTRIBUTES = Map.of("tier", TIER);
     private static final Map<String, String> RAW_ATTRIBUTES = Map.of("tier", TIER);
+    private final String referenceId;
+    private final String referenceType;
 
     @Override
     public @NonNull String getReferenceType() {
-        return REFERENCE_TYPE_PLATFORM;
+        return this.referenceType;
     }
 
     @Override
     public @NonNull String getReferenceId() {
-        return REFERENCE_ID_PLATFORM;
+        return this.referenceId;
     }
 
     @Override

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -162,6 +162,17 @@ class DefaultLicenseFactoryTest {
         );
     }
 
+    @Test
+    void should_return_oss_organization_license() throws InvalidLicenseException {
+        final License license = cut.createOSSOrganization("orgId");
+
+        assertThat(license.getTier()).isEqualTo("oss");
+        assertThat(license.getReferenceId()).isEqualTo("orgId");
+        assertThat(license.getReferenceType()).isEqualTo("ORGANIZATION");
+        assertThat(license.getPacks()).isEmpty();
+        assertThat(license.getFeatures()).isEmpty();
+    }
+
     private void assertUniverseLicense(License license) {
         assertThat(license.getTier()).isEqualTo("universe");
         assertThat(license.getPacks())

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/OSSLicenseTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/OSSLicenseTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
  */
 class OSSLicenseTest {
 
-    private final OSSLicense cut = new OSSLicense();
+    private final OSSLicense cut = new OSSLicense("PLATFORM", "PLATFORM");
 
     @Test
     void should_return_oss_tier() {


### PR DESCRIPTION
…org oss

**Issue**

https://gravitee.atlassian.net/browse/APIM-3564

**Description**

Allow an OSS License to be scoped by either organization or platform.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.6.0-apim-3564-allow-oss-license-to-be-scoped-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.6.0-apim-3564-allow-oss-license-to-be-scoped-SNAPSHOT/gravitee-node-5.6.0-apim-3564-allow-oss-license-to-be-scoped-SNAPSHOT.zip)
  <!-- Version placeholder end -->
