### PR TITLE
fix: support org license expiration

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/license/ExpiredLicenseException.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/license/ExpiredLicenseException.java
@@ -1,0 +1,25 @@
+package io.gravitee.node.api.license;
+
+import java.io.Serial;
+
+/**
+ * {@link ExpiredLicenseException} allows to identify that a license is expired.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ *
+ * @see MalformedLicenseException
+ */
+public class ExpiredLicenseException extends InvalidLicenseException {
+
+    @Serial
+    private static final long serialVersionUID = 8229097167142139226L;
+
+    public ExpiredLicenseException(String message) {
+        super(message);
+    }
+
+    public ExpiredLicenseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/license/InvalidLicenseException.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/license/InvalidLicenseException.java
@@ -3,7 +3,7 @@ package io.gravitee.node.api.license;
 import java.io.Serial;
 
 /**
- * {@link InvalidLicenseException} allows to identify that a license has an invalid signature or is expire.
+ * {@link InvalidLicenseException} allows to identify that a license has an invalid signature or is expired.
  *
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicense.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicense.java
@@ -48,7 +48,12 @@ class DefaultLicense implements License {
 
     @Override
     public boolean isFeatureEnabled(String feature) {
-        return feature == null || features.contains(feature);
+        if (license3j.isValid() && !license3j.isExpired()) {
+            return feature == null || features.contains(feature);
+        }
+
+        // If the underlying license is not valid or is expired then only plugins not requiring any feature are considered enabled.
+        return feature == null;
     }
 
     @Override

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseManager.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseManager.java
@@ -87,8 +87,7 @@ public class DefaultLicenseManager extends AbstractService<LicenseManager> imple
     }
 
     @Override
-    public void validatePluginFeatures(String organizationId, Collection<Plugin> plugins)
-        throws InvalidLicenseException, ForbiddenFeatureException {
+    public void validatePluginFeatures(String organizationId, Collection<Plugin> plugins) throws ForbiddenFeatureException {
         if (plugins == null || plugins.isEmpty()) {
             // There is no plugin feature to validate.
             return;
@@ -96,10 +95,6 @@ public class DefaultLicenseManager extends AbstractService<LicenseManager> imple
 
         final Set<ForbiddenFeature> errors = new HashSet<>();
         final License license = this.getOrganizationLicenseOrPlatform(organizationId);
-
-        if (license.isExpired()) {
-            throw new InvalidLicenseException("The license has expired.");
-        }
 
         plugins.forEach(plugin -> validatePluginFeature(license, errors, plugin));
 

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/OSSLicense.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/OSSLicense.java
@@ -7,25 +7,32 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@NoArgsConstructor
+@AllArgsConstructor
 class OSSLicense implements License {
 
-    private static final String TIER = "oss";
+    static final String TIER = "oss";
     private static final Map<String, Object> ATTRIBUTES = Map.of("tier", TIER);
     private static final Map<String, String> RAW_ATTRIBUTES = Map.of("tier", TIER);
 
+    private String referenceType = REFERENCE_TYPE_PLATFORM;
+    private String referenceId = REFERENCE_ID_PLATFORM;
+
     @Override
     public @NonNull String getReferenceType() {
-        return REFERENCE_TYPE_PLATFORM;
+        return referenceType;
     }
 
     @Override
     public @NonNull String getReferenceId() {
-        return REFERENCE_ID_PLATFORM;
+        return referenceId;
     }
 
     @Override

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/license3j/License3J.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/license3j/License3J.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.node.license.license3j;
 
+import io.gravitee.node.api.license.ExpiredLicenseException;
 import io.gravitee.node.api.license.InvalidLicenseException;
 import java.util.Map;
 import java.util.Optional;
@@ -76,6 +77,7 @@ public class License3J {
     }
 
     private final javax0.license3j.License license;
+    private Boolean valid;
 
     public License3J(javax0.license3j.License license) {
         this.license = license;
@@ -145,14 +147,24 @@ public class License3J {
     }
 
     public void verify() throws InvalidLicenseException {
-        boolean valid = license.isOK(publicKey());
-
-        if (!valid) {
+        if (!isValid()) {
             throw new InvalidLicenseException("License is not valid. Please contact GraviteeSource to ask for a valid license.");
         }
 
-        if (license.isExpired()) {
-            throw new InvalidLicenseException("License is expired. Please contact GraviteeSource to ask for a renewed license.");
+        if (isExpired()) {
+            throw new ExpiredLicenseException("License is expired. Please contact GraviteeSource to ask for a renewed license.");
         }
+    }
+
+    public boolean isValid() {
+        if (valid == null) {
+            valid = license.isOK(publicKey());
+        }
+
+        return valid;
+    }
+
+    public boolean isExpired() {
+        return license.isExpired();
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-332

**Description**

This PR offers better support for org licenses when they expire.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.5.3-archi-332-support-expired-org-licenses-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.5.3-archi-332-support-expired-org-licenses-SNAPSHOT/gravitee-node-5.5.3-archi-332-support-expired-org-licenses-SNAPSHOT.zip)
  <!-- Version placeholder end -->
