### PR TITLE
feat: add reactive method to Cache, Topic and Queue

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/Cache.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/Cache.java
@@ -15,6 +15,10 @@
  */
 package io.gravitee.node.api.cache;
 
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -30,31 +34,91 @@ public interface Cache<K, V> {
 
     int size();
 
+    default Single<Integer> rxSize() {
+        return Single.fromCallable(this::size).subscribeOn(Schedulers.io());
+    }
+
     boolean isEmpty();
+
+    default Single<Boolean> rxIsEmpty() {
+        return Single.fromCallable(this::isEmpty).subscribeOn(Schedulers.io());
+    }
 
     Collection<V> values();
 
+    default Flowable<V> rxValues() {
+        return Flowable.fromIterable(this.values()).subscribeOn(Schedulers.io());
+    }
+
     boolean containsKey(final K key);
+
+    default Single<Boolean> rxContainsKey(final K key) {
+        return Single.fromCallable(() -> this.containsKey(key)).subscribeOn(Schedulers.io());
+    }
 
     V get(final K key);
 
+    default Single<V> rxGet(final K key) {
+        return Single.fromCallable(() -> this.get(key)).subscribeOn(Schedulers.io());
+    }
+
     V put(final K key, final V value);
+
+    default Single<V> rxPut(final K key, final V value) {
+        return Single.fromCallable(() -> this.put(key, value)).subscribeOn(Schedulers.io());
+    }
 
     V put(final K key, final V value, final long ttl, final TimeUnit ttlUnit);
 
+    default Single<V> rxPut(final K key, final V value, final long ttl, final TimeUnit ttlUnit) {
+        return Single.fromCallable(() -> this.put(key, value, ttl, ttlUnit)).subscribeOn(Schedulers.io());
+    }
+
     void putAll(final Map<? extends K, ? extends V> m);
+
+    default Completable rxPutAll(final Map<? extends K, ? extends V> m) {
+        return Completable.fromRunnable(() -> this.putAll(m)).subscribeOn(Schedulers.io());
+    }
 
     V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction);
 
+    default Single<V> rxComputeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        return Single.fromCallable(() -> this.computeIfAbsent(key, mappingFunction)).subscribeOn(Schedulers.io());
+    }
+
     V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction);
+
+    default Single<V> rxComputeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return Single.fromCallable(() -> this.computeIfPresent(key, remappingFunction)).subscribeOn(Schedulers.io());
+    }
 
     V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction);
 
+    default Single<V> rxCompute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return Single.fromCallable(() -> this.compute(key, remappingFunction)).subscribeOn(Schedulers.io());
+    }
+
     V evict(final K key);
+
+    default Single<V> rxEvict(final K key) {
+        return Single.fromCallable(() -> this.evict(key)).subscribeOn(Schedulers.io());
+    }
 
     void clear();
 
+    default Completable rxClear() {
+        return Completable.fromRunnable(this::clear).subscribeOn(Schedulers.io());
+    }
+
     String addCacheListener(CacheListener<K, V> listener);
 
+    default Single<String> rxAddCacheListener(CacheListener<K, V> listener) {
+        return Single.fromCallable(() -> this.addCacheListener(listener)).subscribeOn(Schedulers.io());
+    }
+
     boolean removeCacheListener(final String listenerCacheId);
+
+    default Completable rxRemoveCacheListener(final String listenerCacheId) {
+        return Completable.fromRunnable(() -> this.removeCacheListener(listenerCacheId)).subscribeOn(Schedulers.io());
+    }
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/messaging/Queue.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/messaging/Queue.java
@@ -15,6 +15,10 @@
  */
 package io.gravitee.node.api.cluster.messaging;
 
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
@@ -22,10 +26,21 @@ package io.gravitee.node.api.cluster.messaging;
 public interface Queue<T> {
     /**
      * Publish a new message on the current queue
+     *
      * @param item the item to send
      * @throws IllegalStateException – if the element cannot be added at this time due to capacity restrictions
      */
     void add(T item);
+
+    /**
+     * Reactive version of {@link Queue#add(T)}. By default, execution will be done on IO schedulers.
+     *
+     * @param item the item to send
+     * @return returns a {@code Completable} instance that completes in case of success
+     */
+    default Completable rxAdd(T item) {
+        return Completable.fromRunnable(() -> this.add(item)).subscribeOn(Schedulers.io());
+    }
 
     /**
      * Add a new listener on this queue. The given listener will be notified on any new message on the queue.
@@ -35,9 +50,29 @@ public interface Queue<T> {
     String addMessageListener(final MessageListener<T> messageListener);
 
     /**
+     * Reactive version of {@link Queue#addMessageListener(MessageListener)}. By default, execution will be done on IO schedulers.
+     *
+     * @param messageListener the listener to notify
+     * @return a {@code Single} with the subscription identifier. Could be used to remove this listener.
+     */
+    default Single<String> rxAddMessageListener(final MessageListener<T> messageListener) {
+        return Single.fromCallable(() -> this.addMessageListener(messageListener)).subscribeOn(Schedulers.io());
+    }
+
+    /**
      * Remove a listener on this queue from its subscription id.
      * @param subscriptionId the subscription id used to remove the listener
      * @return <code>true</code> if any listener has been removed, <code>false</code> otherwise.
      */
     boolean removeMessageListener(final String subscriptionId);
+
+    /**
+     * Reactive version of {@link Queue#removeMessageListener(String)}. By default, execution will be done on IO schedulers.
+     *
+     * @param subscriptionId the subscription id used to remove the listener
+     * @return returns a {@code Completable} instance that completes in case of listener has been removed.
+     */
+    default Completable rxRemoveMessageListener(final String subscriptionId) {
+        return Completable.fromRunnable(() -> this.removeMessageListener(subscriptionId)).subscribeOn(Schedulers.io());
+    }
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/messaging/Topic.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/messaging/Topic.java
@@ -15,6 +15,11 @@
  */
 package io.gravitee.node.api.cluster.messaging;
 
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import org.checkerframework.checker.units.qual.C;
+
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
  * @author GraviteeSource Team
@@ -27,6 +32,16 @@ public interface Topic<T> {
     void publish(T event);
 
     /**
+     * Reactive version of {@link Topic#publish(T)}. By default, execution will be done on IO schedulers.
+     *
+     * @param event the event to publish
+     * @return returns a {@code Completable} instance that completes in case of success
+     */
+    default Completable rxPublish(T event) {
+        return Completable.fromRunnable(() -> this.publish(event)).subscribeOn(Schedulers.io());
+    }
+
+    /**
      * Add a new listener on this topic. The given listener will be notified on any new message on the topic.
      * @param messageListener the listener to notify
      * @return the subscription identifier. Could be used to remove this listener.
@@ -34,9 +49,29 @@ public interface Topic<T> {
     String addMessageListener(final MessageListener<T> messageListener);
 
     /**
+     * Reactive version of {@link Queue#addMessageListener(MessageListener)}. By default, execution will be done on IO schedulers.
+     *
+     * @param messageListener the listener to notify
+     * @return a {@code Single} with the subscription identifier. Could be used to remove this listener.
+     */
+    default Single<String> rxAddMessageListener(final MessageListener<T> messageListener) {
+        return Single.fromCallable(() -> this.addMessageListener(messageListener)).subscribeOn(Schedulers.io());
+    }
+
+    /**
      * Remove a listener on this topic from its subscription id.
      * @param subscriptionId the subscription id used to remove the listener
      * @return <code>true</code> if any listener has been removed, <code>false</code> otherwise.
      */
     boolean removeMessageListener(final String subscriptionId);
+
+    /**
+     * Reactive version of {@link Topic#removeMessageListener(String)}. By default, execution will be done on IO schedulers.
+     *
+     * @param subscriptionId the subscription id used to remove the listener
+     * @return returns a {@code Completable} instance that completes in case of listener has been removed.
+     */
+    default Completable rxRemoveMessageListener(final String subscriptionId) {
+        return Completable.fromRunnable(() -> this.removeMessageListener(subscriptionId)).subscribeOn(Schedulers.io());
+    }
 }

--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
@@ -20,6 +20,8 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.map.impl.MapListenerAdapter;
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheListener;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
@@ -69,12 +71,22 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     }
 
     @Override
+    public Single<V> rxGet(final K key) {
+        return Single.fromCompletionStage(this.cache.getAsync(key));
+    }
+
+    @Override
     public V put(K key, V value) {
         if (timeToLiveInMs > 0) {
             return this.cache.put(key, value, timeToLiveInMs, TimeUnit.MILLISECONDS);
         } else {
             return this.cache.put(key, value);
         }
+    }
+
+    @Override
+    public Single<V> rxPut(final K key, final V value) {
+        return Single.fromCompletionStage(this.cache.putAsync(key, value));
     }
 
     @Override
@@ -89,6 +101,11 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
         this.cache.putAll(m);
+    }
+
+    @Override
+    public Completable rxPutAll(final Map<? extends K, ? extends V> m) {
+        return Completable.fromCompletionStage(this.cache.putAllAsync(m));
     }
 
     @Override

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/messaging/HazelcastQueue.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/messaging/HazelcastQueue.java
@@ -21,7 +21,6 @@ import io.gravitee.node.api.cluster.messaging.Message;
 import io.gravitee.node.api.cluster.messaging.MessageListener;
 import io.gravitee.node.api.cluster.messaging.Queue;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/messaging/HazelcastTopic.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/messaging/HazelcastTopic.java
@@ -19,6 +19,8 @@ import com.hazelcast.topic.ITopic;
 import io.gravitee.node.api.cluster.messaging.Message;
 import io.gravitee.node.api.cluster.messaging.MessageListener;
 import io.gravitee.node.api.cluster.messaging.Topic;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.UUID;
 
 /**
@@ -36,6 +38,11 @@ public class HazelcastTopic<T> implements Topic<T> {
     @Override
     public void publish(T event) {
         iTopic.publish(event);
+    }
+
+    @Override
+    public Completable rxPublish(final T event) {
+        return Completable.fromCompletionStage(iTopic.publishAsync(event)).subscribeOn(Schedulers.io());
     }
 
     @Override


### PR DESCRIPTION
**Description**

Add reactive method on cache, Topic and Queue with default implementation and specific one with Hazelcast.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.6.0-add-reactive-api-cache-cluster-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.6.0-add-reactive-api-cache-cluster-SNAPSHOT/gravitee-node-5.6.0-add-reactive-api-cache-cluster-SNAPSHOT.zip)
  <!-- Version placeholder end -->
