### PR TITLE
feat: add interops features

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -28,6 +28,8 @@ packs:
             - am-policy-mfa-challenge
             - am-policy-account-linking
             - apim-policy-graphql-ratelimit
+            - apim-policy-interops-a-idp
+            - apim-policy-interops-r-idp
     enterprise-identity-provider:
         features:
             - am-idp-salesforce

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -283,6 +283,8 @@ class DefaultLicenseFactoryTest {
             "am-resource-sfr",
             "gravitee-en-secretprovider-vault",
             "apim-policy-graphql-ratelimit",
+            "apim-policy-interops-a-idp",
+            "apim-policy-interops-r-idp",
         };
         assertThat(license.getFeatures()).containsExactlyInAnyOrder(features);
 


### PR DESCRIPTION
closes APIM-3616
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.7.0-APIM-3616-inter-ops-policy-qa-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.7.0-APIM-3616-inter-ops-policy-qa-SNAPSHOT/gravitee-node-5.7.0-APIM-3616-inter-ops-policy-qa-SNAPSHOT.zip)
  <!-- Version placeholder end -->
