### PR TITLE
feat: add new cache method

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/Cache.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/Cache.java
@@ -17,10 +17,12 @@ package io.gravitee.node.api.cache;
 
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -31,6 +33,24 @@ import java.util.function.Function;
  */
 public interface Cache<K, V> {
     String getName();
+
+    Collection<V> values();
+
+    default Flowable<V> rxValues() {
+        return Flowable.fromIterable(this.values()).subscribeOn(Schedulers.io());
+    }
+
+    Set<K> keys();
+
+    default Flowable<K> rxKeys() {
+        return Flowable.fromIterable(this.keys()).subscribeOn(Schedulers.io());
+    }
+
+    Set<Map.Entry<K, V>> entrySet();
+
+    default Flowable<Map.Entry<K, V>> rxEntrySet() {
+        return Flowable.fromIterable(this.entrySet()).subscribeOn(Schedulers.io());
+    }
 
     int size();
 
@@ -44,12 +64,6 @@ public interface Cache<K, V> {
         return Single.fromCallable(this::isEmpty).subscribeOn(Schedulers.io());
     }
 
-    Collection<V> values();
-
-    default Flowable<V> rxValues() {
-        return Flowable.fromIterable(this.values()).subscribeOn(Schedulers.io());
-    }
-
     boolean containsKey(final K key);
 
     default Single<Boolean> rxContainsKey(final K key) {
@@ -58,8 +72,8 @@ public interface Cache<K, V> {
 
     V get(final K key);
 
-    default Single<V> rxGet(final K key) {
-        return Single.fromCallable(() -> this.get(key)).subscribeOn(Schedulers.io());
+    default Maybe<V> rxGet(final K key) {
+        return Maybe.fromCallable(() -> this.get(key)).subscribeOn(Schedulers.io());
     }
 
     V put(final K key, final V value);

--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
@@ -21,9 +21,11 @@ import com.hazelcast.map.impl.MapListenerAdapter;
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheListener;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -61,6 +63,16 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     }
 
     @Override
+    public Set<K> keys() {
+        return this.cache.keySet();
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        return this.cache.entrySet();
+    }
+
+    @Override
     public boolean containsKey(final K key) {
         return this.cache.containsKey(key);
     }
@@ -71,8 +83,8 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public Single<V> rxGet(final K key) {
-        return Single.fromCompletionStage(this.cache.getAsync(key));
+    public Maybe<V> rxGet(final K key) {
+        return Maybe.fromCompletionStage(this.cache.getAsync(key));
     }
 
     @Override


### PR DESCRIPTION

**Description**

Add some methods as entrySet, values, keys.


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.7.0-improve-cache-interface-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.7.0-improve-cache-interface-SNAPSHOT/gravitee-node-5.7.0-improve-cache-interface-SNAPSHOT.zip)
  <!-- Version placeholder end -->
