### PR TITLE
fix: support private ca as truststore

### DIFF
--- a/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/AbstractKeyStoreLoaderManager.java
+++ b/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/AbstractKeyStoreLoaderManager.java
@@ -74,14 +74,6 @@ public class AbstractKeyStoreLoaderManager {
     }
 
     /**
-     *
-     * @return true the manager requires to use a password to add entries to the keystore. By convention the same password as the keystore is used.
-     */
-    protected boolean requirePassword() {
-        return true;
-    }
-
-    /**
      * <p>Creates the main keystore. And register and starts the platform keystore loader.
      * This that can only be done once, that is why it is synchronized at the method level.
      * </p>
@@ -190,14 +182,15 @@ public class AbstractKeyStoreLoaderManager {
 
     private void addKeyStore(IdProvider loader, KeyStoreEvent.LoadEvent event) {
         try {
-            for (String alias : Collections.list(event.keyStore().aliases())) {
+            final KeyStore source = event.keyStore();
+            for (String alias : Collections.list(source.aliases())) {
                 String newAlias = scopeAlias(loader, alias);
-                if (requirePassword() && event.keyStore().isKeyEntry(alias)) {
+                if (source.isKeyEntry(alias)) {
                     // Only key entries can be password protected.
-                    KeyStore.Entry exisingEntry = event.keyStore().getEntry(alias, event.passwordAsProtection());
+                    KeyStore.Entry exisingEntry = source.getEntry(alias, event.passwordAsProtection());
                     mainKeyStore.setEntry(newAlias, exisingEntry, passwordProtection);
                 } else {
-                    KeyStore.Entry exisingEntry = event.keyStore().getEntry(alias, null);
+                    KeyStore.Entry exisingEntry = source.getEntry(alias, null);
                     mainKeyStore.setEntry(newAlias, exisingEntry, null);
                 }
             }
@@ -235,7 +228,7 @@ public class AbstractKeyStoreLoaderManager {
             var destination = KeyStore.getInstance(KeyStoreUtils.DEFAULT_KEYSTORE_TYPE);
             destination.load(null, mainPassword);
             for (String alias : Collections.list(source.aliases())) {
-                if (requirePassword() && source.isKeyEntry(alias)) {
+                if (source.isKeyEntry(alias)) {
                     // Only key entries can be password protected.
                     final KeyStore.Entry entry = source.getEntry(alias, passwordProtection);
                     destination.setEntry(alias, entry, passwordProtection);

--- a/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/DefaultKeyStoreLoaderFactoryRegistry.java
+++ b/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/DefaultKeyStoreLoaderFactoryRegistry.java
@@ -19,6 +19,7 @@ import io.gravitee.node.api.certificate.*;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Default implementation of {@link KeyStoreLoaderFactory} interface, for Javadoc see interface
@@ -28,6 +29,7 @@ import java.util.Set;
  */
 public class DefaultKeyStoreLoaderFactoryRegistry<O extends AbstractStoreLoaderOptions> implements KeyStoreLoaderFactoryRegistry<O> {
 
+    protected static final NoOpKeyStoreLoader NO_OP_KEY_STORE_LOADER = new NoOpKeyStoreLoader();
     private final Set<KeyStoreLoaderFactory<O>> loaderFactories;
 
     public DefaultKeyStoreLoaderFactoryRegistry() {
@@ -62,18 +64,13 @@ public class DefaultKeyStoreLoaderFactoryRegistry<O extends AbstractStoreLoaderO
             .stream()
             .findFirst()
             .map(keyStoreLoaderFactory -> keyStoreLoaderFactory.create(options))
-            .orElse(new NoOpKeyStoreLoader<>(options));
+            .orElse(NO_OP_KEY_STORE_LOADER);
     }
 
     /**
-     * When no factory is found this clas is returned signifying that nothing will be done. This allows to always have a {@link KeyStoreLoader} instead of dealing with null
-     * @param <O>
+     * When no factory is found this class is returned signifying that nothing will be done. This allows to always have a {@link KeyStoreLoader} instead of dealing with null
      */
-    static class NoOpKeyStoreLoader<O extends AbstractStoreLoaderOptions> extends AbstractKeyStoreLoader<O> {
-
-        NoOpKeyStoreLoader(O options) {
-            super(options);
-        }
+    static class NoOpKeyStoreLoader implements KeyStoreLoader {
 
         @Override
         public void start() {
@@ -84,6 +81,9 @@ public class DefaultKeyStoreLoaderFactoryRegistry<O extends AbstractStoreLoaderO
         public void stop() {
             // no op
         }
+
+        @Override
+        public void setEventHandler(Consumer<KeyStoreEvent> handler) {}
 
         @Override
         public String id() {

--- a/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/TrustStoreLoaderManager.java
+++ b/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/TrustStoreLoaderManager.java
@@ -32,11 +32,6 @@ public class TrustStoreLoaderManager extends AbstractKeyStoreLoaderManager {
         super(target, platformKeyStoreLoader, new RefreshableX509TrustManagerDelegator(target));
     }
 
-    @Override
-    protected boolean requirePassword() {
-        return false;
-    }
-
     /**
      *
      * @return JDK {@link javax.net.ssl.TrustManager}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-340

**Description**

This PR fixes back the support for private ca as truststore.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.8.1-archi-340-support-private-ca-for-truststore-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.8.1-archi-340-support-private-ca-for-truststore-SNAPSHOT/gravitee-node-5.8.1-archi-340-support-private-ca-for-truststore-SNAPSHOT.zip)
  <!-- Version placeholder end -->
