### PR TITLE
feat: a null license on create returns an oss license

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/license/LicenseFactory.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/license/LicenseFactory.java
@@ -16,11 +16,11 @@ public interface LicenseFactory {
      * @param referenceId the reference id the license is created for.
      * @param base64License a base64 encoded string representing the license data.
      *
-     * @return the created {@link License}.
+     * @return the created {@link License}. An OSS license is returned if base64License is null.
      * @throws InvalidLicenseException thrown if the specified license data is invalid.
      * @throws MalformedLicenseException thrown if the license is malformed.
      */
-    License create(@Nonnull String referenceType, @Nonnull String referenceId, @Nonnull String base64License)
+    License create(@Nonnull String referenceType, @Nonnull String referenceId, String base64License)
         throws InvalidLicenseException, MalformedLicenseException;
 
     /**
@@ -30,11 +30,11 @@ public interface LicenseFactory {
      * @param referenceId the reference id the license is created for.
      *
      * @param bytesLicense a byte array representing the license data.
-     * @return the created {@link License}.
+     * @return the created {@link License}. An OSS license is returned if bytesLicense is null.
      * @throws InvalidLicenseException thrown if the specified license data is invalid.
 
      * @throws MalformedLicenseException thrown if the license is malformed.
      */
-    License create(@Nonnull String referenceType, @Nonnull String referenceId, @Nonnull byte[] bytesLicense)
+    License create(@Nonnull String referenceType, @Nonnull String referenceId, byte[] bytesLicense)
         throws InvalidLicenseException, MalformedLicenseException;
 }

--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseFactory.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseFactory.java
@@ -47,15 +47,18 @@ public class DefaultLicenseFactory implements LicenseFactory {
     }
 
     @Override
-    public License create(@Nonnull String referenceType, @Nonnull String referenceId, @Nonnull String base64License)
+    public License create(@Nonnull String referenceType, @Nonnull String referenceId, String base64License)
         throws InvalidLicenseException, MalformedLicenseException {
-        return create(referenceType, referenceId, Base64.getDecoder().decode(base64License));
+        byte[] bytesLicense = Objects.isNull(base64License) ? null : Base64.getDecoder().decode(base64License);
+        return create(referenceType, referenceId, bytesLicense);
     }
 
     @Override
-    public License create(@Nonnull String referenceType, @Nonnull String referenceId, @Nonnull byte[] bytesLicense)
+    public License create(@Nonnull String referenceType, @Nonnull String referenceId, byte[] bytesLicense)
         throws InvalidLicenseException, MalformedLicenseException {
-        if (referenceType.equals(License.REFERENCE_TYPE_PLATFORM)) {
+        if (Objects.isNull(bytesLicense)) {
+            return new OSSLicense(referenceType, referenceId);
+        } else if (referenceType.equals(License.REFERENCE_TYPE_PLATFORM)) {
             return createPlatformLicense(bytesLicense);
         } else {
             return createOrgLicence(referenceId, bytesLicense);

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -37,6 +37,8 @@ class DefaultLicenseFactoryTest {
         "AAAAhAAAADAAAAAlsaWNlbnNlSWSJNcURfozT6Dz/mg0RFEjmAAAAnAAAAAEAAAAQAAAAgGxpY2Vuc2VTaWduYXR1cmWD2AVRDn0G07Yn4fXIx/vz4f8gu3RPNWt" +
         "JlsrGyRpLp+0du2lt7sFea/RJNNTqyNAWrtABljvf5dKcNxa4JIANKINX3t+508k6SejaUs0kOqfcL7Sztv2IbqJddIqCxPRsZInL9Htw7beMBJ9XYAGCgaHIrAN" +
         "VgTPojI4gvmfD2QAAACIAAAACAAAADwAAAAdzaWduYXR1cmVEaWdlc3RTSEEtMjU2AAAAGAAAAAIAAAAEAAAACHRpZXJ1bml2ZXJzZQ==";
+    private static final String NULL_LICENSE = null;
+    private static final byte[] NULL_BYTES_ARRAY = null;
     protected static final String ORG_ID = "orgId";
 
     private static LicenseKeyPair keyPair;
@@ -199,6 +201,54 @@ class DefaultLicenseFactoryTest {
         assertThat(license.getPacks()).isEmpty();
         assertThat(license.getFeatures()).isEmpty();
         assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_ORGANIZATION);
+        assertThat(license.getReferenceId()).isEqualTo(ORG_ID);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_oss_license_when_org_license_is_null() {
+        final License license = cut.create(REFERENCE_TYPE_ORGANIZATION, ORG_ID, NULL_LICENSE);
+
+        assertThat(license.getTier()).isEqualTo(OSSLicense.TIER);
+        assertThat(license.getPacks()).isEmpty();
+        assertThat(license.getFeatures()).isEmpty();
+        assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_ORGANIZATION);
+        assertThat(license.getReferenceId()).isEqualTo(ORG_ID);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_oss_license_when_platform_license_is_null() {
+        final License license = cut.create(REFERENCE_TYPE_PLATFORM, ORG_ID, NULL_LICENSE);
+
+        assertThat(license.getTier()).isEqualTo(OSSLicense.TIER);
+        assertThat(license.getPacks()).isEmpty();
+        assertThat(license.getFeatures()).isEmpty();
+        assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_PLATFORM);
+        assertThat(license.getReferenceId()).isEqualTo(ORG_ID);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_oss_license_when_org_bytes_array_is_null() {
+        final License license = cut.create(REFERENCE_TYPE_ORGANIZATION, ORG_ID, NULL_BYTES_ARRAY);
+
+        assertThat(license.getTier()).isEqualTo(OSSLicense.TIER);
+        assertThat(license.getPacks()).isEmpty();
+        assertThat(license.getFeatures()).isEmpty();
+        assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_ORGANIZATION);
+        assertThat(license.getReferenceId()).isEqualTo(ORG_ID);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_oss_license_when_platform_bytes_array_is_null() {
+        final License license = cut.create(REFERENCE_TYPE_PLATFORM, ORG_ID, NULL_BYTES_ARRAY);
+
+        assertThat(license.getTier()).isEqualTo(OSSLicense.TIER);
+        assertThat(license.getPacks()).isEmpty();
+        assertThat(license.getFeatures()).isEmpty();
+        assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_PLATFORM);
         assertThat(license.getReferenceId()).isEqualTo(ORG_ID);
     }
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4183

**Description**

When the base64 license is null, then an OSS license is returned.

Cockpit can delete an organization license, which effectively sends a payload with `license: null`. In this case, the `create` should yield an OSS license that APIM (Gateway + MAPI) can then use in `registerOrganizationLicense`.  

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.10.0-apim-4183-handle-null-org-license-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.10.0-apim-4183-handle-null-org-license-SNAPSHOT/gravitee-node-5.10.0-apim-4183-handle-null-org-license-SNAPSHOT.zip)
  <!-- Version placeholder end -->
