### PR TITLE
feat: handle keep-alive timeout

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
@@ -106,6 +106,7 @@ public class VertxHttpClientFactory {
             .setPipelining(httpOptions.isPipelining())
             .setKeepAlive(httpOptions.isKeepAlive())
             .setIdleTimeout((int) (httpOptions.getIdleTimeout() / 1000))
+            .setKeepAliveTimeout((int) (httpOptions.getKeepAliveTimeout() / 1000))
             .setConnectTimeout((int) httpOptions.getConnectTimeout())
             .setMaxPoolSize(httpOptions.getMaxConcurrentConnections())
             .setDecompressionSupported(httpOptions.isUseCompression())

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
@@ -38,6 +38,7 @@ public class VertxHttpClientOptions implements Serializable {
     private static final long serialVersionUID = -7061411805967594667L;
 
     public static final long DEFAULT_IDLE_TIMEOUT = 60000;
+    public static final long DEFAULT_KEEP_ALIVE_TIMEOUT = 30000;
     public static final long DEFAULT_CONNECT_TIMEOUT = 5000;
     public static final long DEFAULT_READ_TIMEOUT = 10000;
     public static final int DEFAULT_MAX_CONCURRENT_CONNECTIONS = 100;
@@ -50,6 +51,7 @@ public class VertxHttpClientOptions implements Serializable {
     public static final VertxHttpProtocolVersion DEFAULT_PROTOCOL_VERSION = VertxHttpProtocolVersion.HTTP_1_1;
 
     private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
+    private long keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
     private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private boolean keepAlive = DEFAULT_KEEP_ALIVE;
     private long readTimeout = DEFAULT_READ_TIMEOUT;

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactoryTest.java
@@ -398,6 +398,7 @@ class VertxHttpClientFactoryTest {
                       "followRedirects": false,
                       "readTimeout": 10000,
                       "idleTimeout": 60000,
+                      "keepAliveTimeout": 30000,
                       "connectTimeout": 5000,
                       "propagateClientAcceptEncoding": true,
                       "useCompression": false,


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3966

**Description**

Add the possibility to configure the keep-alive timeout.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.11.0-apim-3966-configure-keepalive-timeout-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.11.0-apim-3966-configure-keepalive-timeout-SNAPSHOT/gravitee-node-5.11.0-apim-3966-configure-keepalive-timeout-SNAPSHOT.zip)
  <!-- Version placeholder end -->
