### PR TITLE
fix: set http2-max-header-list-size option from the provided config

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
@@ -185,6 +185,7 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         options.setCompressionSupported(compressionSupported);
         options.setMaxChunkSize(maxChunkSize);
         options.setMaxHeaderSize(maxHeaderSize);
+        options.getInitialSettings().setMaxHeaderListSize(maxHeaderSize);
         options.setMaxInitialLineLength(maxInitialLineLength);
         options.setMaxFormAttributeSize(maxFormAttributeSize);
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4468

Description

set http2-max-header-list-size option from the provided config

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.12.3-APIM-4468-http2-max-header-size-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.12.3-APIM-4468-http2-max-header-size-master-SNAPSHOT/gravitee-node-5.12.3-APIM-4468-http2-max-header-size-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
