### PR TITLE
Configure alpn option even if not secured - 4.8.x

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
@@ -64,7 +64,6 @@ public class HttpServerSpringConfiguration {
 
         if (httpServerConfiguration.isSecured()) {
             options.setSsl(httpServerConfiguration.isSecured());
-            options.setUseAlpn(httpServerConfiguration.isAlpn());
 
             String clientAuth = httpServerConfiguration.getClientAuth();
             if (!StringUtils.isEmpty(clientAuth)) {
@@ -122,6 +121,7 @@ public class HttpServerSpringConfiguration {
             }
         }
         options.setIdleTimeout(httpServerConfiguration.getIdleTimeout());
+        options.setUseAlpn(httpServerConfiguration.isAlpn());
 
         return vertx.createHttpServer(options);
     }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
@@ -164,7 +164,6 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         setupTcp(options);
 
         if (this.secured) {
-            options.setUseAlpn(alpn);
             options.setSni(sni);
 
             // Specify client auth (mtls).
@@ -176,6 +175,7 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         }
 
         // Customizable configuration
+        options.setUseAlpn(alpn);
         options.setHandle100ContinueAutomatically(handle100Continue);
         options.setCompressionSupported(compressionSupported);
         options.setMaxChunkSize(maxChunkSize);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4560
https://github.com/gravitee-io/issues/issues/9671

**Description**

Configure alpn option even if not secured.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.8.5-apim-4560-fix-alpn-configuration-4-8-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.8.5-apim-4560-fix-alpn-configuration-4-8-x-SNAPSHOT/gravitee-node-4.8.5-apim-4560-fix-alpn-configuration-4-8-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
