### PR TITLE
Configure alpn option even if not secured - master

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
@@ -64,7 +64,6 @@ public class HttpServerSpringConfiguration {
 
         if (httpServerConfiguration.isSecured()) {
             options.setSsl(httpServerConfiguration.isSecured());
-            options.setUseAlpn(httpServerConfiguration.isAlpn());
 
             String clientAuth = httpServerConfiguration.getClientAuth();
             if (!StringUtils.isEmpty(clientAuth)) {
@@ -122,6 +121,7 @@ public class HttpServerSpringConfiguration {
             }
         }
         options.setIdleTimeout(httpServerConfiguration.getIdleTimeout());
+        options.setUseAlpn(httpServerConfiguration.isAlpn());
 
         return vertx.createHttpServer(options);
     }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
@@ -113,7 +113,8 @@ public class VertxHttpClientFactory {
             .setTryUsePerFrameWebSocketCompression(httpOptions.isUseCompression())
             .setTryUsePerMessageWebSocketCompression(httpOptions.isUseCompression())
             .setWebSocketCompressionAllowClientNoContext(httpOptions.isUseCompression())
-            .setWebSocketCompressionRequestServerNoContext(httpOptions.isUseCompression());
+            .setWebSocketCompressionRequestServerNoContext(httpOptions.isUseCompression())
+            .setUseAlpn(true);
 
         if (httpOptions.getVersion() == VertxHttpProtocolVersion.HTTP_2) {
             options
@@ -177,8 +178,6 @@ public class VertxHttpClientFactory {
                 }
             }
         }
-
-        options.setUseAlpn(true);
     }
 
     private void setSystemProxy(final io.vertx.core.http.HttpClientOptions options) {

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
@@ -169,7 +169,6 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         setupTcp(options, vertxKeyCertOptions, vertxTrustOptions);
 
         if (this.secured) {
-            options.setUseAlpn(alpn);
             options.setSni(sni);
 
             // Specify client auth (mtls).
@@ -181,6 +180,7 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         }
 
         // Customizable configuration
+        options.setUseAlpn(alpn);
         options.setHandle100ContinueAutomatically(handle100Continue);
         options.setCompressionSupported(compressionSupported);
         options.setMaxChunkSize(maxChunkSize);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4560
https://github.com/gravitee-io/issues/issues/9671

**Description**

Configure alpn option even if not secured.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.12.4-apim-4560-fix-alpn-configuration-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.12.4-apim-4560-fix-alpn-configuration-master-SNAPSHOT/gravitee-node-5.12.4-apim-4560-fix-alpn-configuration-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
