### PR TITLE
feat: add new option for TcpClient to manage hostname verification al…

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
@@ -25,6 +25,7 @@ public class SslOptions implements Serializable {
 
     private boolean trustAll;
     private boolean hostnameVerifier = true;
+    private String hostnameVerificationAlgorithm = "NONE";
     private TrustStore trustStore;
     private KeyStore keyStore;
 

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientFactory.java
@@ -94,6 +94,13 @@ public class VertxTcpClientFactory {
                 clientOptions.setSslEngineOptions(new OpenSSLEngineOptions());
             }
 
+            String hostnameVerificationAlgorithm = sslOptions.getHostnameVerificationAlgorithm();
+            if ("NONE".equals(hostnameVerificationAlgorithm)) {
+                clientOptions.setHostnameVerificationAlgorithm("");
+            } else {
+                clientOptions.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+            }
+
             clientOptions.setTrustAll(sslOptions.isTrustAll());
 
             try {


### PR DESCRIPTION
…gorithm

- to avoid BC, default value is set to NONE
- this change is needed before updating the BOM to 8.x

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-345

**Description**

Add a new option for TcpClient to manage hostname verification algorithm and set a default value to NONE (which result in an empty string in Vert.x ClientOptions) to avoid any BC. 
This change is needed before upgrading the BOM to 8.x which comes with Vert.x 4.5.7 (https://github.com/vert-x3/wiki/wiki/4.5.4-Deprecations-and-breaking-changes#breaking-change-in-the-tls-configuration-of-tcp-client).

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.13.0-feat-add-hostnamealgorithm-option-tcp-client-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.13.0-feat-add-hostnamealgorithm-option-tcp-client-SNAPSHOT/gravitee-node-5.13.0-feat-add-hostnamealgorithm-option-tcp-client-SNAPSHOT.zip)
  <!-- Version placeholder end -->
