### PR TITLE
fix(deps): upgrade gravitee-bom to 8.x

### DIFF
--- a/gravitee-node-secrets/gravitee-node-secrets-service/pom.xml
+++ b/gravitee-node-secrets/gravitee-node-secrets-service/pom.xml
@@ -60,13 +60,11 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>${bouncycastle.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>${bouncycastle.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>7.0.18</gravitee-bom.version>
+        <gravitee-bom.version>8.0.3</gravitee-bom.version>
         <gravitee-common.version>3.3.3</gravitee-common.version>
         <gravitee-plugin.version>3.1.0</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
@@ -69,9 +69,8 @@
         <awaitability.version>4.2.0</awaitability.version>
 
         <!-- WARNING: the next two dependencies versions must be kept in sync regarding vertx-micrometer-metrics -->
-        <micrometer-registry-prometheus.version>1.10.7</micrometer-registry-prometheus.version>
+        <micrometer-registry-prometheus.version>1.12.4</micrometer-registry-prometheus.version>
         <LatencyUtils.version>2.0.3</LatencyUtils.version>
-        <bouncycastle.version>1.77</bouncycastle.version>
         <guava.version>32.0.1-jre</guava.version>
         <license3j.version>3.2.0</license3j.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
@@ -215,16 +214,6 @@
                 <groupId>io.gravitee.kubernetes</groupId>
                 <artifactId>gravitee-kubernetes-client</artifactId>
                 <version>${gravitee-kubernetes.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
- remove bouncycastle from dependency management (included in bom now)
- align micrometer-registry-prometheus version to the version used by vert.x

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-345

**Description**

Update gravitee bom to 8.x version, remove bouncycastle as it is now managed in the bom and align the micrometer-registry-prometheus version to the version used by vert.x 

