### PR TITLE
fix: missing Builder.Default in SslOptions on new property hostnameVe…

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
@@ -25,7 +25,10 @@ public class SslOptions implements Serializable {
 
     private boolean trustAll;
     private boolean hostnameVerifier = true;
+
+    @Builder.Default
     private String hostnameVerificationAlgorithm = "NONE";
+
     private TrustStore trustStore;
     private KeyStore keyStore;
 


### PR DESCRIPTION
…rificationAlgorithm

**Description**

Fixed missing annotation Builder.Default on new property hostnameVerificationAlgorithm in SslOptions added after bom upgrade.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.14.2-fix-ssl-options-missing-builder-default-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.14.2-fix-ssl-options-missing-builder-default-SNAPSHOT/gravitee-node-5.14.2-fix-ssl-options-missing-builder-default-SNAPSHOT.zip)
  <!-- Version placeholder end -->
