### PR TITLE
fix: add orange contact everyone plugin

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -51,6 +51,7 @@ packs:
             - am-resource-http-factor
             - am-mfa-sms
             - am-mfa-call
+            - am-resource-orange-contact-everyone
     observability:
         features:
             - apim-reporter-tcp

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
@@ -153,7 +153,8 @@ class NodeLicenseServiceTest {
                 "apim-en-entrypoint-sse",
                 "apim-reporter-tcp",
                 "policy-data-logging-masking",
-                "am-idp-gateway-handler-saml"
+                "am-idp-gateway-handler-saml",
+                "am-resource-orange-contact-everyone"
             );
     }
 


### PR DESCRIPTION
Fixes: AM-3077
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-AM-3077-orange-plugin-v4-0-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.0.1-AM-3077-orange-plugin-v4-0-x-SNAPSHOT/gravitee-node-4.0.1-AM-3077-orange-plugin-v4-0-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
