### PR TITLE
Revert ALPN changes - 4.8.x

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
@@ -64,6 +64,7 @@ public class HttpServerSpringConfiguration {
 
         if (httpServerConfiguration.isSecured()) {
             options.setSsl(httpServerConfiguration.isSecured());
+            options.setUseAlpn(httpServerConfiguration.isAlpn());
 
             String clientAuth = httpServerConfiguration.getClientAuth();
             if (!StringUtils.isEmpty(clientAuth)) {
@@ -121,7 +122,6 @@ public class HttpServerSpringConfiguration {
             }
         }
         options.setIdleTimeout(httpServerConfiguration.getIdleTimeout());
-        options.setUseAlpn(httpServerConfiguration.isAlpn());
 
         return vertx.createHttpServer(options);
     }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
@@ -164,6 +164,7 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         setupTcp(options);
 
         if (this.secured) {
+            options.setUseAlpn(alpn);
             options.setSni(sni);
 
             // Specify client auth (mtls).
@@ -175,7 +176,6 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         }
 
         // Customizable configuration
-        options.setUseAlpn(alpn);
         options.setHandle100ContinueAutomatically(handle100Continue);
         options.setCompressionSupported(compressionSupported);
         options.setMaxChunkSize(maxChunkSize);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4560

**Description**

This reverts commit ad5456df338311e0cad3c835387615d13d27c027.

ALPN makes no sens without TLS
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.8.6-revert-alpn-changes-4-8-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.8.6-revert-alpn-changes-4-8-SNAPSHOT/gravitee-node-4.8.6-revert-alpn-changes-4-8-SNAPSHOT.zip)
  <!-- Version placeholder end -->
