### PR TITLE
Revert ALPN changes

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/spring/HttpServerSpringConfiguration.java
@@ -64,6 +64,7 @@ public class HttpServerSpringConfiguration {
 
         if (httpServerConfiguration.isSecured()) {
             options.setSsl(httpServerConfiguration.isSecured());
+            options.setUseAlpn(httpServerConfiguration.isAlpn());
 
             String clientAuth = httpServerConfiguration.getClientAuth();
             if (!StringUtils.isEmpty(clientAuth)) {
@@ -121,7 +122,6 @@ public class HttpServerSpringConfiguration {
             }
         }
         options.setIdleTimeout(httpServerConfiguration.getIdleTimeout());
-        options.setUseAlpn(httpServerConfiguration.isAlpn());
 
         return vertx.createHttpServer(options);
     }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
@@ -113,8 +113,7 @@ public class VertxHttpClientFactory {
             .setTryUsePerFrameWebSocketCompression(httpOptions.isUseCompression())
             .setTryUsePerMessageWebSocketCompression(httpOptions.isUseCompression())
             .setWebSocketCompressionAllowClientNoContext(httpOptions.isUseCompression())
-            .setWebSocketCompressionRequestServerNoContext(httpOptions.isUseCompression())
-            .setUseAlpn(true);
+            .setWebSocketCompressionRequestServerNoContext(httpOptions.isUseCompression());
 
         if (httpOptions.getVersion() == VertxHttpProtocolVersion.HTTP_2) {
             options
@@ -178,6 +177,8 @@ public class VertxHttpClientFactory {
                 }
             }
         }
+
+        options.setUseAlpn(true);
     }
 
     private void setSystemProxy(final io.vertx.core.http.HttpClientOptions options) {

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/server/http/VertxHttpServerOptions.java
@@ -169,6 +169,7 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         setupTcp(options, vertxKeyCertOptions, vertxTrustOptions);
 
         if (this.secured) {
+            options.setUseAlpn(alpn);
             options.setSni(sni);
 
             // Specify client auth (mtls).
@@ -180,7 +181,6 @@ public class VertxHttpServerOptions extends VertxServerOptions {
         }
 
         // Customizable configuration
-        options.setUseAlpn(alpn);
         options.setHandle100ContinueAutomatically(handle100Continue);
         options.setCompressionSupported(compressionSupported);
         options.setMaxChunkSize(maxChunkSize);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4560

**Description**

This reverts commit eb54cffdac2fd1d6403f3da016517f020e0f92c1.

ALPN makes no sens without TLS
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.14.3-revert-alpn-changes-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.14.3-revert-alpn-changes-SNAPSHOT/gravitee-node-5.14.3-revert-alpn-changes-SNAPSHOT.zip)
  <!-- Version placeholder end -->
