### PR TITLE
fix: add Interops SP plugins

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -30,6 +30,8 @@ packs:
             - apim-policy-graphql-ratelimit
             - apim-policy-interops-a-idp
             - apim-policy-interops-r-idp
+            - apim-policy-interops-a-sp
+            - apim-policy-interops-r-sp
     enterprise-identity-provider:
         features:
             - am-idp-salesforce

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -336,6 +336,8 @@ class DefaultLicenseFactoryTest {
             "apim-policy-graphql-ratelimit",
             "apim-policy-interops-a-idp",
             "apim-policy-interops-r-idp",
+            "apim-policy-interops-a-sp",
+            "apim-policy-interops-r-sp",
         };
         assertThat(license.getFeatures()).containsExactlyInAnyOrder(features);
 


### PR DESCRIPTION
cherry pick from 7604631
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.14.4-mergify-add-interops-sp-plugins-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.14.4-mergify-add-interops-sp-plugins-SNAPSHOT/gravitee-node-5.14.4-mergify-add-interops-sp-plugins-SNAPSHOT.zip)
  <!-- Version placeholder end -->
