### PR TITLE
fix: add AM HTTP resource plugin

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -55,6 +55,7 @@ packs:
             - am-mfa-call
             - am-resource-sfr
             - am-resource-orange-contact-everyone
+            - am-resource-http
     observability:
         features:
             - apim-reporter-tcp

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
@@ -157,7 +157,8 @@ class NodeLicenseServiceTest {
                 "am-policy-mfa-challenge",
                 "am-policy-account-linking",
                 "am-resource-sfr",
-                "am-resource-orange-contact-everyone"
+                "am-resource-orange-contact-everyone",
+                "am-resource-http"
             );
     }
 


### PR DESCRIPTION
fixes AM-3293
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.3-mergify-bp-4-3-x-AM-3293-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.3.3-mergify-bp-4-3-x-AM-3293-SNAPSHOT/gravitee-node-4.3.3-mergify-bp-4-3-x-AM-3293-SNAPSHOT.zip)
  <!-- Version placeholder end -->
