### PR TITLE
fix: remove misleading options in vertx client factory

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
@@ -20,9 +20,7 @@ import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -58,13 +56,6 @@ public class VertxHttpClientOptions implements Serializable {
     private boolean pipelining = DEFAULT_PIPELINING;
     private int maxConcurrentConnections = DEFAULT_MAX_CONCURRENT_CONNECTIONS;
     private boolean useCompression = DEFAULT_USE_COMPRESSION;
-    private boolean propagateClientAcceptEncoding = DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING;
-    private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
     private boolean clearTextUpgrade = DEFAULT_CLEAR_TEXT_UPGRADE;
     private VertxHttpProtocolVersion version = DEFAULT_PROTOCOL_VERSION;
-
-    public boolean isPropagateClientAcceptEncoding() {
-        // Propagate Accept-Encoding can only be made if useCompression is disabled.
-        return !useCompression && propagateClientAcceptEncoding;
-    }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-364

Remove misleading usage of Vertx Http Client Options.
During recent refactoring `io.gravitee.definition.model.v4.http.HttpClientOptions` has been mapped 1:1 with `io.gravitee.node.vertx.client.http.VertxHttpClientOptions` but some options are not  applicable.


**Description**

* followRedirect cannot be used in VertxClientOptions, it is a request option. It is handled as such in proxy connector: no risk
* propagateClientAcceptHeader cannot be used in VertxClientOptions, it is proxy connector logic: no risk

*Warning* they are impact in APIM (test compile issue) hence the non breaking change nature of this PR, but a change will be requested in APIM as soon as this PR is merged.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

