### PR TITLE
feat: add oas validation policy feature to license

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -22,6 +22,7 @@ packs:
             - apim-policy-data-logging-masking
             - policy-data-logging-masking # for removal
             - apim-policy-geoip-filtering
+            - apim-policy-oas-validation
             - apim-policy-transform-avro-json
             - apim-policy-transform-protobuf-json
             - apim-policy-transform-avro-protobuf

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -341,6 +341,7 @@ class DefaultLicenseFactoryTest {
             "apim-policy-interops-r-idp",
             "apim-policy-interops-a-sp",
             "apim-policy-interops-r-sp",
+            "apim-policy-oas-validation",
         };
         assertThat(license.getFeatures()).containsExactlyInAnyOrder(features);
 


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-4164

**Description**

Add oas validation policy feature to license.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.16.0-APIM-4164-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.16.0-APIM-4164-SNAPSHOT/gravitee-node-5.16.0-APIM-4164-SNAPSHOT.zip)
  <!-- Version placeholder end -->
