### PR TITLE
feat: reduce pressure on db due to health and monitoring

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/Probe.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/Probe.java
@@ -18,14 +18,40 @@ package io.gravitee.node.api.healthcheck;
 import java.util.concurrent.CompletionStage;
 
 /**
+ * Represents a probe that can be evaluated and used for monitoring purpose.
+ *
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface Probe {
+    /**
+     * The identifier of the probe (ex: 'cpu', 'memory', ...).
+     * @return
+     */
     String id();
 
+    /**
+     * Evaluate the probe and return a result indicating if it is healthy or not.
+     *
+     * @return a {@link CompletionStage} containing the result of the evaluation.
+     */
     CompletionStage<Result> check();
 
+    /**
+     * Indicates if the probe requests caching to avoid too many evaluations that can have an impact on performances.
+     * Note: the probe itself is not mandatory to implement caching. This is the responsibility of the invoker to implement the caching of the result.
+     *
+     * @return <code>true</code> if the probe requests caching, <code>false</code> otherwise. Default is <code>false</code>.
+     */
+    default boolean isCacheable() {
+        return false;
+    }
+
+    /**
+     * Indicates if the probe should be evaluated and visible by default by the health check.
+     *
+     * @return <code>true</code> if the probe should be visible, <code>false</code> otherwise. Default is <code>true</code>.
+     */
     default boolean isVisibleByDefault() {
         return true;
     }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/ProbeEvaluator.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/ProbeEvaluator.java
@@ -1,0 +1,20 @@
+package io.gravitee.node.api.healthcheck;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This registry that holds all the registered probes (see {@link ProbeManager}) and allows evaluating them in a single call.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ProbeEvaluator {
+    /**
+     * Evaluate all the registered probes.
+     * In case a {@link Probe} is cacheable, the probe will be checked again only if the time elapsed since the last evaluation is above a particular threshold.
+     *
+     * @return a {@link CompletableFuture} with the map of all evaluated probes.
+     */
+    CompletableFuture<Map<Probe, Result>> evaluate();
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
@@ -1,0 +1,68 @@
+package io.gravitee.node.monitoring;
+
+import io.gravitee.node.api.healthcheck.Probe;
+import io.gravitee.node.api.healthcheck.ProbeEvaluator;
+import io.gravitee.node.api.healthcheck.ProbeManager;
+import io.gravitee.node.api.healthcheck.Result;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class DefaultProbeEvaluator implements ProbeEvaluator {
+
+    protected static final long SAFEGUARD_DELAY = 5000L;
+
+    private final long cacheDurationMs;
+    private final ProbeManager probeManager;
+    private final Map<Probe, Result> lastProbeResults = new ConcurrentHashMap<>();
+    private Long lastEvaluation;
+
+    @Override
+    public CompletableFuture<Map<Probe, Result>> evaluate() {
+        final long now = Instant.now().toEpochMilli();
+        final long elapsedTime = lastEvaluation != null ? now - lastEvaluation : Long.MAX_VALUE;
+
+        if (elapsedTime < SAFEGUARD_DELAY) {
+            // Avoid too much pressure evaluating probes.
+            return CompletableFuture.completedFuture(lastProbeResults);
+        }
+
+        final List<CompletableFuture<Void>> collect =
+            this.probeManager.getProbes()
+                .stream()
+                .map(probe -> {
+                    if (probe.isCacheable()) {
+                        if (elapsedTime < cacheDurationMs && lastProbeResults.containsKey(probe)) {
+                            // The probe has been evaluated once and the elapsed time is below the cache limit. Don't re-evaluate.
+                            return CompletableFuture.<Void>completedFuture(null);
+                        }
+                    }
+
+                    // Evaluate the probe and update the probe map.
+                    return probe
+                        .check()
+                        .exceptionally(Result::unhealthy)
+                        .thenAccept(result -> lastProbeResults.compute(probe, (probe1, result1) -> result))
+                        .toCompletableFuture();
+                })
+                .toList();
+
+        // Ensure all the probes have been resolved and return all the results.
+        return CompletableFuture
+            .allOf(collect.toArray(new CompletableFuture[0]))
+            .thenApply(unused -> lastProbeResults)
+            .whenComplete((probeResultMap, throwable) -> {
+                if (throwable == null) {
+                    lastEvaluation = now;
+                }
+            });
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/probe/CPUProbe.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/probe/CPUProbe.java
@@ -15,21 +15,26 @@
  */
 package io.gravitee.node.monitoring.healthcheck.probe;
 
-import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.api.healthcheck.Probe;
 import io.gravitee.node.api.healthcheck.Result;
 import io.gravitee.node.monitoring.monitor.probe.ProcessProbe;
+import io.gravitee.node.monitoring.spring.HealthConfiguration;
 import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@NoArgsConstructor
+@AllArgsConstructor
 public class CPUProbe implements Probe {
 
     @Autowired
-    private Configuration configuration;
+    private HealthConfiguration healthConfiguration;
 
     @Override
     public String id() {
@@ -45,16 +50,12 @@ public class CPUProbe implements Probe {
     public CompletableFuture<Result> check() {
         try {
             return CompletableFuture.supplyAsync(() ->
-                ProcessProbe.getInstance().getProcessCpuPercent() < threshold()
+                ProcessProbe.getInstance().getProcessCpuPercent() < healthConfiguration.cpuThreshold()
                     ? Result.healthy()
-                    : Result.unhealthy(String.format("CPU percent is over the threshold of %d %%", threshold()))
+                    : Result.unhealthy(String.format("CPU percent is over the threshold of %d %%", healthConfiguration.cpuThreshold()))
             );
         } catch (Exception ex) {
             return CompletableFuture.completedFuture(Result.unhealthy(ex));
         }
-    }
-
-    private int threshold() {
-        return configuration.getProperty("services.health.threshold.cpu", Integer.class, 80);
     }
 }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/probe/MemoryProbe.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/probe/MemoryProbe.java
@@ -15,21 +15,25 @@
  */
 package io.gravitee.node.monitoring.healthcheck.probe;
 
-import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.api.healthcheck.Probe;
 import io.gravitee.node.api.healthcheck.Result;
 import io.gravitee.node.monitoring.monitor.probe.JvmProbe;
+import io.gravitee.node.monitoring.spring.HealthConfiguration;
 import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@NoArgsConstructor
+@AllArgsConstructor
 public class MemoryProbe implements Probe {
 
     @Autowired
-    private Configuration configuration;
+    private HealthConfiguration healthConfiguration;
 
     @Override
     public String id() {
@@ -45,16 +49,14 @@ public class MemoryProbe implements Probe {
     public CompletableFuture<Result> check() {
         try {
             return CompletableFuture.supplyAsync(() ->
-                JvmProbe.getInstance().jvmInfo().mem.getHeapUsedPercent() < threshold()
+                JvmProbe.getInstance().jvmInfo().mem.getHeapUsedPercent() < healthConfiguration.memoryThreshold()
                     ? Result.healthy()
-                    : Result.unhealthy(String.format("Memory percent is over the threshold of %d %%", threshold()))
+                    : Result.unhealthy(
+                        String.format("Memory percent is over the threshold of %d %%", healthConfiguration.memoryThreshold())
+                    )
             );
         } catch (Exception ex) {
             return CompletableFuture.completedFuture(Result.unhealthy(ex));
         }
-    }
-
-    private int threshold() {
-        return configuration.getProperty("services.health.threshold.memory", Integer.class, 80);
     }
 }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorManagementEndpoint.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorManagementEndpoint.java
@@ -29,20 +29,18 @@ import io.gravitee.node.monitoring.monitor.probe.OsProbe;
 import io.gravitee.node.monitoring.monitor.probe.ProcessProbe;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
+@RequiredArgsConstructor
 public class NodeMonitorManagementEndpoint implements ManagementEndpoint {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NodeMonitorManagementEndpoint.class);
-
-    @Autowired
-    private ObjectMapper mapper;
+    private final ObjectMapper mapper;
 
     @Override
     public HttpMethod method() {
@@ -73,7 +71,7 @@ public class NodeMonitorManagementEndpoint implements ManagementEndpoint {
             response.setStatusCode(HttpStatusCode.OK_200);
             response.write(mapper.writeValueAsString(root));
         } catch (JsonProcessingException e) {
-            LOGGER.error("Unexpected error while generating monitoring", e);
+            log.error("Unexpected error while generating monitoring", e);
             response.setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
         }
 

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/HealthConfiguration.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/HealthConfiguration.java
@@ -1,0 +1,9 @@
+package io.gravitee.node.monitoring.spring;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record HealthConfiguration(boolean enabled, long delay, TimeUnit unit, int cpuThreshold, int memoryThreshold) {}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/MonitoringConfiguration.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/MonitoringConfiguration.java
@@ -1,0 +1,9 @@
+package io.gravitee.node.monitoring.spring;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record MonitoringConfiguration(boolean enabled, long delay, TimeUnit unit) {}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/DefaultProbeEvaluatorTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/DefaultProbeEvaluatorTest.java
@@ -1,0 +1,210 @@
+package io.gravitee.node.monitoring;
+
+import static io.gravitee.node.monitoring.DefaultProbeEvaluator.SAFEGUARD_DELAY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.healthcheck.Probe;
+import io.gravitee.node.api.healthcheck.ProbeManager;
+import io.gravitee.node.api.healthcheck.Result;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class DefaultProbeEvaluatorTest {
+
+    protected static final int CACHE_DURATION_MS = 30000;
+
+    @Mock
+    private ProbeManager probeManager;
+
+    @Mock
+    private Probe probe1;
+
+    @Mock
+    private Probe probe2;
+
+    private DefaultProbeEvaluator cut;
+
+    @Test
+    void should_complete_and_check_all_probes_when_evaluate() {
+        when(probe1.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+        when(probe2.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+        when(probeManager.getProbes()).thenReturn(List.of(probe1, probe2));
+
+        cut = new DefaultProbeEvaluator(0, probeManager);
+
+        final CompletableFuture<Map<Probe, Result>> result = cut.evaluate();
+
+        assertThat(result)
+            .isCompletedWithValueMatching(probeResultMap -> {
+                assertThat(probeResultMap.get(probe1)).isEqualTo(Result.healthy());
+                assertThat(probeResultMap.get(probe2)).isEqualTo(Result.healthy());
+                return true;
+            });
+
+        verify(probe1).check();
+        verify(probe2).check();
+    }
+
+    @Test
+    void should_complete_with_probe_unhealthy_when_probe_unhealthy() {
+        when(probe1.check()).thenReturn(CompletableFuture.completedFuture(Result.unhealthy("unhealthy")));
+        when(probe2.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+        when(probeManager.getProbes()).thenReturn(List.of(probe1, probe2));
+
+        cut = new DefaultProbeEvaluator(0, probeManager);
+
+        final CompletableFuture<Map<Probe, Result>> result = cut.evaluate();
+
+        assertThat(result)
+            .isCompletedWithValueMatching(probeResultMap -> {
+                assertThat(probeResultMap.get(probe1)).isEqualTo(Result.unhealthy("unhealthy"));
+                assertThat(probeResultMap.get(probe2)).isEqualTo(Result.healthy());
+                return true;
+            });
+
+        verify(probe1).check();
+        verify(probe2).check();
+    }
+
+    @Test
+    void should_complete_with_probe_unhealthy_when_probe_failed_to_be_evaluated() {
+        final Exception error = new Exception("Mock error");
+
+        when(probe1.check()).thenReturn(CompletableFuture.failedFuture(error));
+        when(probe2.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+        when(probeManager.getProbes()).thenReturn(List.of(probe1, probe2));
+
+        cut = new DefaultProbeEvaluator(0, probeManager);
+
+        final CompletableFuture<Map<Probe, Result>> result = cut.evaluate();
+
+        assertThat(result)
+            .isCompletedWithValueMatching(probeResultMap -> {
+                assertThat(probeResultMap.get(probe1)).isEqualTo(Result.unhealthy(error));
+                assertThat(probeResultMap.get(probe2)).isEqualTo(Result.healthy());
+                return true;
+            });
+
+        verify(probe1).check();
+        verify(probe2).check();
+    }
+
+    @Test
+    void should_use_cached_results_when_safeguard_delay_is_not_elapsed() {
+        when(probe1.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+        when(probe2.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+        when(probeManager.getProbes()).thenReturn(List.of(probe1, probe2));
+
+        cut = new DefaultProbeEvaluator(CACHE_DURATION_MS, probeManager);
+
+        // Evaluate first time.
+        assertThat(cut.evaluate()).isCompleted();
+
+        // Re-evaluate and check the probe1 cached result has been returned.
+        final CompletableFuture<Map<Probe, Result>> result = cut.evaluate();
+
+        assertThat(result)
+            .isCompletedWithValueMatching(probeResultMap -> {
+                assertThat(probeResultMap.get(probe1)).isEqualTo(Result.healthy());
+                assertThat(probeResultMap.get(probe2)).isEqualTo(Result.healthy());
+                return true;
+            });
+
+        // Should have been called once.
+        verify(probe1).check();
+        verify(probe2).check();
+    }
+
+    @Test
+    void should_use_cached_result_when_probe_is_cacheable() {
+        MockedStatic<Instant> mockedStaticInstant = null;
+
+        try {
+            when(probe1.isCacheable()).thenReturn(true);
+            when(probe1.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+            when(probe2.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+            when(probeManager.getProbes()).thenReturn(List.of(probe1, probe2));
+
+            cut = new DefaultProbeEvaluator(CACHE_DURATION_MS, probeManager);
+
+            // Evaluate first time.
+            assertThat(cut.evaluate()).isCompleted();
+
+            final Instant instant = Instant.now().plus(SAFEGUARD_DELAY + 1000, ChronoUnit.MILLIS);
+            mockedStaticInstant = mockStatic(Instant.class);
+            mockedStaticInstant.when(Instant::now).thenReturn(instant);
+
+            // Re-evaluate and check the probe1 cached result has been returned.
+            final CompletableFuture<Map<Probe, Result>> result = cut.evaluate();
+
+            assertThat(result)
+                .isCompletedWithValueMatching(probeResultMap -> {
+                    assertThat(probeResultMap.get(probe1)).isEqualTo(Result.healthy());
+                    assertThat(probeResultMap.get(probe2)).isEqualTo(Result.healthy());
+                    return true;
+                });
+
+            verify(probe1).check();
+            verify(probe2, times(2)).check();
+        } finally {
+            if (mockedStaticInstant != null) {
+                mockedStaticInstant.close();
+            }
+        }
+    }
+
+    @Test
+    void should_re_evaluate_probe_when_probe_cache_delay_is_elapsed() {
+        MockedStatic<Instant> mockedStaticInstant = null;
+
+        try {
+            when(probe1.isCacheable()).thenReturn(true);
+            when(probe1.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+            when(probe2.check()).thenReturn(CompletableFuture.completedFuture(Result.healthy()));
+            when(probeManager.getProbes()).thenReturn(List.of(probe1, probe2));
+
+            cut = new DefaultProbeEvaluator(CACHE_DURATION_MS, probeManager);
+
+            // Evaluate first time.
+            assertThat(cut.evaluate()).isCompleted();
+
+            final Instant instant = Instant.now().plus(CACHE_DURATION_MS + 1000, ChronoUnit.MILLIS);
+            mockedStaticInstant = mockStatic(Instant.class);
+            mockedStaticInstant.when(Instant::now).thenReturn(instant);
+
+            // Re-evaluate and check the probe1 cached result has been returned.
+            final CompletableFuture<Map<Probe, Result>> result = cut.evaluate();
+
+            assertThat(result)
+                .isCompletedWithValueMatching(probeResultMap -> {
+                    assertThat(probeResultMap.get(probe1)).isEqualTo(Result.healthy());
+                    assertThat(probeResultMap.get(probe2)).isEqualTo(Result.healthy());
+                    return true;
+                });
+
+            verify(probe1, times(2)).check();
+            verify(probe2, times(2)).check();
+        } finally {
+            if (mockedStaticInstant != null) {
+                mockedStaticInstant.close();
+            }
+        }
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckServiceTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckServiceTest.java
@@ -1,0 +1,87 @@
+package io.gravitee.node.monitoring.healthcheck;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.Node;
+import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
+import io.gravitee.node.monitoring.DefaultProbeEvaluator;
+import io.gravitee.node.monitoring.spring.HealthConfiguration;
+import io.gravitee.plugin.alert.AlertEventProducer;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.micrometer.backends.BackendRegistries;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class NodeHealthCheckServiceTest {
+
+    protected static final String NODE_ID = "NODE_ID";
+
+    @Mock
+    private ManagementEndpointManager managementEndpointManager;
+
+    @Mock
+    private DefaultProbeEvaluator probeRegistry;
+
+    @Mock
+    private NodeHealthCheckManagementEndpoint healthCheckEndpoint;
+
+    @Mock
+    private AlertEventProducer alertEventProducer;
+
+    @Mock
+    private Node node;
+
+    @Test
+    @SneakyThrows
+    void should_start_the_service_when_enabled() {
+        final NodeHealthCheckService cut = new NodeHealthCheckService(
+            managementEndpointManager,
+            probeRegistry,
+            healthCheckEndpoint,
+            alertEventProducer,
+            node,
+            Vertx.vertx(),
+            new HealthConfiguration(true, 1, MILLISECONDS, 0, 0)
+        );
+
+        try (MockedStatic<BackendRegistries> backendRegistries = Mockito.mockStatic(BackendRegistries.class)) {
+            backendRegistries.when(BackendRegistries::getDefaultNow).thenReturn(mock(PrometheusMeterRegistry.class));
+
+            cut.doStart();
+
+            verify(managementEndpointManager).register(healthCheckEndpoint);
+            verify(probeRegistry, atLeastOnce()).evaluate();
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void should_not_start_the_service_when_disabled() {
+        final NodeHealthCheckService cut = new NodeHealthCheckService(
+            managementEndpointManager,
+            probeRegistry,
+            healthCheckEndpoint,
+            alertEventProducer,
+            node,
+            Vertx.vertx(),
+            new HealthConfiguration(false, 1, MILLISECONDS, 0, 0)
+        );
+
+        cut.doStart();
+
+        verify(managementEndpointManager, never()).register(healthCheckEndpoint);
+        verify(probeRegistry, never()).evaluate();
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckThreadTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckThreadTest.java
@@ -1,0 +1,108 @@
+package io.gravitee.node.monitoring.healthcheck;
+
+import static io.gravitee.node.monitoring.MonitoringConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.alert.api.event.Event;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.healthcheck.HealthCheck;
+import io.gravitee.node.api.healthcheck.Probe;
+import io.gravitee.node.api.healthcheck.Result;
+import io.gravitee.node.monitoring.DefaultProbeEvaluator;
+import io.gravitee.plugin.alert.AlertEventProducer;
+import io.vertx.core.eventbus.MessageProducer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class NodeHealthCheckThreadTest {
+
+    protected static final String NODE_ID = "NODE_ID";
+
+    @Mock
+    private DefaultProbeEvaluator probeRegistry;
+
+    @Mock
+    private AlertEventProducer alertEventProducer;
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private MessageProducer<HealthCheck> producer;
+
+    private NodeHealthCheckThread cut;
+
+    @BeforeEach
+    void init() {
+        cut = new NodeHealthCheckThread(probeRegistry, alertEventProducer, producer, node);
+    }
+
+    @Test
+    void should_produce_a_health_check_and_an_alert_event() {
+        final Map<Probe, Result> probeResultMap = fakeProbeResults();
+
+        final Set<String> orgIds = Set.of("ORG_ID");
+        final Set<String> envIds = Set.of("ENV_ID");
+
+        when(node.id()).thenReturn(NODE_ID);
+        when(node.application()).thenReturn("APPLICATION");
+        when(node.hostname()).thenReturn("HOSTNAME");
+        when(node.metadata()).thenReturn(Map.of(Node.META_ORGANIZATIONS, orgIds, Node.META_ENVIRONMENTS, envIds));
+        when(probeRegistry.evaluate()).thenReturn(CompletableFuture.completedFuture(probeResultMap));
+
+        cut.run();
+
+        verify(producer)
+            .write(
+                argThat(healthCheck -> {
+                    assertThat(healthCheck.isHealthy()).isFalse();
+                    assertThat(healthCheck.getEvaluatedAt()).isNotNull();
+                    assertThat(healthCheck.getResults()).isNotNull();
+                    assertThat(healthCheck.getResults().keySet())
+                        .containsAll(probeResultMap.keySet().stream().filter(Probe::isVisibleByDefault).map(Probe::id).toList());
+
+                    return true;
+                })
+            );
+
+        verify(alertEventProducer)
+            .send(
+                argThat(event -> {
+                    assertThat(event.type()).isEqualTo(NODE_HEALTHCHECK);
+                    assertThat(event.properties().get(PROPERTY_NODE_ID)).isEqualTo(NODE_ID);
+                    assertThat(event.properties().get(PROPERTY_NODE_HEALTHY)).isEqualTo("false");
+                    assertThat(event.properties().get(PROPERTY_NODE_HOSTNAME)).isEqualTo("HOSTNAME");
+                    assertThat(event.properties().get(PROPERTY_NODE_APPLICATION)).isEqualTo("APPLICATION");
+                    assertThat(event.properties().get(Event.PROPERTY_ORGANIZATION)).isEqualTo("ORG_ID");
+                    assertThat(event.properties().get(Event.PROPERTY_ENVIRONMENT)).isEqualTo("ENV_ID");
+
+                    return true;
+                })
+            );
+    }
+
+    private Map<Probe, Result> fakeProbeResults() {
+        Map<Probe, Result> probesMap = new HashMap<>();
+        probesMap.put(new TestingProbe("http-server"), Result.healthy());
+        probesMap.put(new TestingProbe("management-repository"), Result.unhealthy("Mock unhealthy"));
+        probesMap.put(new TestingProbe("ratelimit-repository"), Result.healthy());
+        probesMap.put(new TestingProbe("cpu", false), Result.healthy());
+
+        return probesMap;
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/TestingProbe.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/TestingProbe.java
@@ -1,0 +1,35 @@
+package io.gravitee.node.monitoring.healthcheck;
+
+import io.gravitee.node.api.healthcheck.Probe;
+import io.gravitee.node.api.healthcheck.Result;
+import java.util.concurrent.CompletableFuture;
+
+class TestingProbe implements Probe {
+
+    private final String id;
+    private boolean isVisibleByDefault = true;
+
+    public TestingProbe(String id) {
+        this.id = id;
+    }
+
+    public TestingProbe(String id, boolean isVisibleByDefault) {
+        this.id = id;
+        this.isVisibleByDefault = isVisibleByDefault;
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public boolean isVisibleByDefault() {
+        return this.isVisibleByDefault;
+    }
+
+    @Override
+    public CompletableFuture<Result> check() {
+        return null;
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/CPUProbeTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/CPUProbeTest.java
@@ -1,0 +1,37 @@
+package io.gravitee.node.monitoring.healthcheck.probe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.gravitee.node.api.healthcheck.Result;
+import io.gravitee.node.monitoring.spring.HealthConfiguration;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class CPUProbeTest {
+
+    @Test
+    @SneakyThrows
+    void should_be_healthy_when_cpu_threshold_is_not_reached() {
+        final CPUProbe cpuProbe = new CPUProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, Integer.MAX_VALUE, 80));
+
+        final Result result = cpuProbe.check().get();
+
+        assertThat(result.isHealthy()).isTrue();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_be_unhealthy_when_cpu_threshold_is_reached() {
+        final CPUProbe cpuProbe = new CPUProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, Integer.MIN_VALUE, 80));
+
+        final Result result = cpuProbe.check().get();
+
+        assertThat(result.isHealthy()).isFalse();
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/MemoryProbeTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/MemoryProbeTest.java
@@ -1,0 +1,36 @@
+package io.gravitee.node.monitoring.healthcheck.probe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.healthcheck.Result;
+import io.gravitee.node.monitoring.spring.HealthConfiguration;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class MemoryProbeTest {
+
+    @Test
+    @SneakyThrows
+    void should_be_healthy_when_memory_threshold_is_not_reached() {
+        final MemoryProbe cpuProbe = new MemoryProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, 80, Integer.MAX_VALUE));
+
+        final Result result = cpuProbe.check().get();
+
+        assertThat(result.isHealthy()).isTrue();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_be_unhealthy_when_memory_threshold_is_reached() {
+        final MemoryProbe cpuProbe = new MemoryProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, 80, Integer.MIN_VALUE));
+
+        final Result result = cpuProbe.check().get();
+
+        assertThat(result.isHealthy()).isFalse();
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/NodeMonitorServiceTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/NodeMonitorServiceTest.java
@@ -1,0 +1,153 @@
+package io.gravitee.node.monitoring.monitor;
+
+import static io.gravitee.node.monitoring.MonitoringConstants.*;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.alert.api.event.Event;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
+import io.gravitee.node.monitoring.spring.MonitoringConfiguration;
+import io.gravitee.plugin.alert.AlertEventProducer;
+import io.vertx.core.Vertx;
+import java.util.Map;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class NodeMonitorServiceTest {
+
+    protected static final String NODE_ID = "NODE_ID";
+
+    @Mock
+    private NodeMonitorManagementEndpoint nodeMonitorManagementEndpoint;
+
+    @Mock
+    private ManagementEndpointManager managementEndpointManager;
+
+    @Mock
+    private AlertEventProducer alertEventProducer;
+
+    @Mock
+    private Node node;
+
+    @Test
+    @SneakyThrows
+    void should_start_the_service_when_enabled() {
+        final NodeMonitorService cut = new NodeMonitorService(
+            nodeMonitorManagementEndpoint,
+            managementEndpointManager,
+            alertEventProducer,
+            node,
+            Vertx.vertx(),
+            new MonitoringConfiguration(true, 1, MILLISECONDS)
+        );
+
+        final Set<String> orgIds = Set.of("ORG_ID");
+        final Set<String> envIds = Set.of("ENV_ID");
+
+        when(node.id()).thenReturn(NODE_ID);
+        when(node.application()).thenReturn("APPLICATION");
+        when(node.hostname()).thenReturn("HOSTNAME");
+        when(node.metadata()).thenReturn(Map.of(Node.META_ORGANIZATIONS, orgIds, Node.META_ENVIRONMENTS, envIds));
+
+        cut.doStart();
+
+        verify(alertEventProducer)
+            .send(
+                argThat(event -> {
+                    assertThat(event.type()).isEqualTo(NODE_LIFECYCLE);
+                    assertThat(event.properties().get(PROPERTY_NODE_EVENT)).isEqualTo(NODE_EVENT_START);
+                    assertThat(event.properties().get(PROPERTY_NODE_ID)).isEqualTo(NODE_ID);
+                    assertThat(event.properties().get(PROPERTY_NODE_HOSTNAME)).isEqualTo("HOSTNAME");
+                    assertThat(event.properties().get(PROPERTY_NODE_APPLICATION)).isEqualTo("APPLICATION");
+                    assertThat(event.properties().get(Event.PROPERTY_ORGANIZATION)).isEqualTo("ORG_ID");
+                    assertThat(event.properties().get(Event.PROPERTY_ENVIRONMENT)).isEqualTo("ENV_ID");
+
+                    return true;
+                })
+            );
+    }
+
+    @Test
+    @SneakyThrows
+    void should_not_start_the_service_when_disabled() {
+        final NodeMonitorService cut = new NodeMonitorService(
+            nodeMonitorManagementEndpoint,
+            managementEndpointManager,
+            alertEventProducer,
+            node,
+            Vertx.vertx(),
+            new MonitoringConfiguration(false, 1, MILLISECONDS)
+        );
+
+        cut.doStart();
+
+        verify(alertEventProducer, never()).send(any());
+    }
+
+    @Test
+    @SneakyThrows
+    void should_pre_stop_the_service_when_enabled() {
+        final NodeMonitorService cut = new NodeMonitorService(
+            nodeMonitorManagementEndpoint,
+            managementEndpointManager,
+            alertEventProducer,
+            node,
+            Vertx.vertx(),
+            new MonitoringConfiguration(true, 1, MILLISECONDS)
+        );
+
+        final Set<String> orgIds = Set.of("ORG_ID");
+        final Set<String> envIds = Set.of("ENV_ID");
+
+        when(node.id()).thenReturn(NODE_ID);
+        when(node.application()).thenReturn("APPLICATION");
+        when(node.hostname()).thenReturn("HOSTNAME");
+        when(node.metadata()).thenReturn(Map.of(Node.META_ORGANIZATIONS, orgIds, Node.META_ENVIRONMENTS, envIds));
+
+        cut.preStop();
+
+        verify(alertEventProducer)
+            .send(
+                argThat(event -> {
+                    assertThat(event.type()).isEqualTo(NODE_LIFECYCLE);
+                    assertThat(event.properties().get(PROPERTY_NODE_EVENT)).isEqualTo(NODE_EVENT_STOP);
+                    assertThat(event.properties().get(PROPERTY_NODE_ID)).isEqualTo(NODE_ID);
+                    assertThat(event.properties().get(PROPERTY_NODE_HOSTNAME)).isEqualTo("HOSTNAME");
+                    assertThat(event.properties().get(PROPERTY_NODE_APPLICATION)).isEqualTo("APPLICATION");
+                    assertThat(event.properties().get(Event.PROPERTY_ORGANIZATION)).isEqualTo("ORG_ID");
+                    assertThat(event.properties().get(Event.PROPERTY_ENVIRONMENT)).isEqualTo("ENV_ID");
+
+                    return true;
+                })
+            );
+    }
+
+    @Test
+    @SneakyThrows
+    void should_not_pre_stop_the_service_when_disabled() {
+        final NodeMonitorService cut = new NodeMonitorService(
+            nodeMonitorManagementEndpoint,
+            managementEndpointManager,
+            alertEventProducer,
+            node,
+            Vertx.vertx(),
+            new MonitoringConfiguration(false, 1, MILLISECONDS)
+        );
+
+        cut.preStop();
+
+        verify(alertEventProducer, never()).send(any());
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/NodeMonitorThreadTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/NodeMonitorThreadTest.java
@@ -1,0 +1,102 @@
+package io.gravitee.node.monitoring.monitor;
+
+import static io.gravitee.node.monitoring.MonitoringConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.alert.api.event.Event;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.monitor.Monitor;
+import io.gravitee.plugin.alert.AlertEventProducer;
+import io.vertx.core.eventbus.MessageProducer;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class NodeMonitorThreadTest {
+
+    protected static final String NODE_ID = "NODE_ID";
+
+    @Mock
+    private MessageProducer<Monitor> producer;
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private AlertEventProducer alertEventProducer;
+
+    private NodeMonitorThread cut;
+
+    @BeforeEach
+    void init() {
+        cut = new NodeMonitorThread(producer, node, alertEventProducer);
+    }
+
+    @Test
+    void should_produce_a_monitor() {
+        when(node.id()).thenReturn(NODE_ID);
+        cut.run();
+
+        verify(producer)
+            .write(
+                argThat(monitor -> {
+                    assertThat(monitor.getNodeId()).isEqualTo(NODE_ID);
+                    assertThat(monitor.getJvm()).isNotNull();
+                    assertThat(monitor.getOs()).isNotNull();
+                    assertThat(monitor.getProcess()).isNotNull();
+
+                    return true;
+                })
+            );
+    }
+
+    @Test
+    void should_produce_a_monitor_and_send_alert_event_producers_are_available() {
+        final Set<String> orgIds = Set.of("ORG_ID");
+        final Set<String> envIds = Set.of("ENV_ID");
+
+        when(node.id()).thenReturn(NODE_ID);
+        when(node.application()).thenReturn("APPLICATION");
+        when(node.hostname()).thenReturn("HOSTNAME");
+        when(node.metadata()).thenReturn(Map.of(Node.META_ORGANIZATIONS, orgIds, Node.META_ENVIRONMENTS, envIds));
+        when(alertEventProducer.isEmpty()).thenReturn(false);
+
+        cut.run();
+
+        verify(producer).write(any(Monitor.class));
+        verify(alertEventProducer)
+            .send(
+                argThat(event -> {
+                    assertThat(event.type()).isEqualTo(NODE_HEARTBEAT);
+                    assertThat(event.properties().get(PROPERTY_NODE_ID)).isEqualTo(NODE_ID);
+                    assertThat(event.properties().get(PROPERTY_NODE_HOSTNAME)).isEqualTo("HOSTNAME");
+                    assertThat(event.properties().get(PROPERTY_NODE_APPLICATION)).isEqualTo("APPLICATION");
+                    assertThat(event.properties().get(Event.PROPERTY_ORGANIZATION)).isEqualTo("ORG_ID");
+                    assertThat(event.properties().get(Event.PROPERTY_ENVIRONMENT)).isEqualTo("ENV_ID");
+
+                    assertThat(event.properties().keySet()).contains("os.cpu.percent", "process.fd.open", "jvm.uptime");
+                    return true;
+                })
+            );
+    }
+
+    @Test
+    void should_catch_any_exception() {
+        when(producer.write(any(Monitor.class))).thenThrow(new RuntimeException("Mock exception"));
+
+        cut.run();
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-365

**Description**

This PR refactor the way the probes are evaluated by the healthcheck. It introduces a `ProbeRegistry` that is responsible for evaluating the probes and dealing with caching.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.15.0-archi-365-reduce-repository-pressure-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.15.0-archi-365-reduce-repository-pressure-SNAPSHOT/gravitee-node-5.15.0-archi-365-reduce-repository-pressure-SNAPSHOT.zip)
  <!-- Version placeholder end -->
