### PR TITLE
feat: add secret provider aws to license model

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -87,6 +87,7 @@ packs:
     enterprise-secret-manager:
         features:
             - gravitee-en-secretprovider-vault
+            - gravitee-en-secretprovider-aws
     enterprise-alert-engine:
         features:
             - alert-engine

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -336,6 +336,7 @@ class DefaultLicenseFactoryTest {
             "am-resource-orange-contact-everyone",
             "am-resource-http",
             "gravitee-en-secretprovider-vault",
+            "gravitee-en-secretprovider-aws",
             "apim-policy-graphql-ratelimit",
             "apim-policy-interops-a-idp",
             "apim-policy-interops-r-idp",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AM-3308

**Description**

Add secret provider aws to license model

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.18.0-feat-secretprovider-aws-license-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.18.0-feat-secretprovider-aws-license-SNAPSHOT/gravitee-node-5.18.0-feat-secretprovider-aws-license-SNAPSHOT.zip)
  <!-- Version placeholder end -->
