### PR TITLE
[4.6.x] fix: recursive method call may lead to stack overflow exception

### DIFF
--- a/gravitee-node-container/src/test/java/io/gravitee/node/container/spring/env/WatchablePropertyResolverSubscriberTest.java
+++ b/gravitee-node-container/src/test/java/io/gravitee/node/container/spring/env/WatchablePropertyResolverSubscriberTest.java
@@ -1,0 +1,29 @@
+package io.gravitee.node.container.spring.env;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Supplier;
+import io.reactivex.rxjava3.schedulers.TestScheduler;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class WatchablePropertyResolverSubscriberTest {
+
+    @Test
+    public void shouldRepeatFlowableWhenItsCompleted() {
+        int secondsDelay = 1;
+        TestScheduler testScheduler = new TestScheduler();
+
+        Supplier<Flowable<String>> flowableSupplier = () -> Flowable.just("1", "2");
+        TestSubscriber<String> test = new AbstractGraviteePropertySource.FlowableRepeater<>(flowableSupplier)
+            .repeatFlowable(secondsDelay, testScheduler)
+            .test();
+
+        testScheduler.advanceTimeBy(5, TimeUnit.SECONDS);
+        test.assertNotComplete();
+        test.assertValueCount(10);
+        testScheduler.advanceTimeBy(3, TimeUnit.SECONDS);
+        test.assertValueCount(16);
+        test.assertNotComplete();
+    }
+}


### PR DESCRIPTION
fixes AM-3317, stacktrace details in https://gravitee.atlassian.net/browse/AM-3317

StackOverflowError is thrown due to recursive loop on watchProperty(). 
As a remedy, the main Flowable<T> is wrapped to Flowable.defer(Supplier<Flowable>) and chained with repeat() 

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.6.4-AM-3317-fix-stackoverflow-ex-on-watch-loop-4-6-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.6.4-AM-3317-fix-stackoverflow-ex-on-watch-loop-4-6-SNAPSHOT/gravitee-node-4.6.4-AM-3317-fix-stackoverflow-ex-on-watch-loop-4-6-SNAPSHOT.zip)
  <!-- Version placeholder end -->
