### PR TITLE
fix: added one-second delay before repeat to avoid log flooding in ca…

### DIFF
--- a/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/env/AbstractGraviteePropertySource.java
+++ b/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/env/AbstractGraviteePropertySource.java
@@ -19,10 +19,13 @@ import io.gravitee.node.api.secrets.resolver.PropertyResolver;
 import io.gravitee.node.api.secrets.resolver.PropertyResolverFactoriesLoader;
 import io.gravitee.node.api.secrets.resolver.WatchablePropertyResolver;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.functions.Supplier;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -34,6 +37,8 @@ import org.springframework.util.Assert;
  * @author GraviteeSource Team
  */
 public abstract class AbstractGraviteePropertySource extends EnumerablePropertySource<Map<String, Object>> {
+
+    private static final int REPEAT_DELAY_SECONDS = 1;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGraviteePropertySource.class);
     private final PropertyResolverFactoriesLoader propertyResolverLoader;
@@ -82,10 +87,9 @@ public abstract class AbstractGraviteePropertySource extends EnumerablePropertyS
     protected abstract Object getValue(String key);
 
     private void watchProperty(WatchablePropertyResolver<?> propertyResolver, String name, Object value) {
-        Flowable
-            .defer(() -> propertyResolver.watch(value.toString()))
+        new FlowableRepeater(() -> propertyResolver.watch(value.toString()))
+            .repeatFlowable(REPEAT_DELAY_SECONDS)
             .subscribeOn(Schedulers.io())
-            .repeat()
             .subscribe(newValue -> source.put(name, newValue), t -> LOGGER.error("Unable to update property {}", name, t));
     }
 
@@ -101,5 +105,22 @@ public abstract class AbstractGraviteePropertySource extends EnumerablePropertyS
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), propertyResolverLoader);
+    }
+
+    static class FlowableRepeater<T> {
+
+        private final Supplier<Flowable<T>> flowableSupplier;
+
+        FlowableRepeater(Supplier<Flowable<T>> flowableSupplier) {
+            this.flowableSupplier = flowableSupplier;
+        }
+
+        Flowable<T> repeatFlowable(int recreateDelaySeconds) {
+            return Flowable.defer(flowableSupplier).delay(recreateDelaySeconds, TimeUnit.SECONDS).repeat();
+        }
+
+        Flowable<T> repeatFlowable(int recreateDelaySeconds, Scheduler delayScheduler) {
+            return Flowable.defer(flowableSupplier).delay(recreateDelaySeconds, TimeUnit.SECONDS, delayScheduler).repeat();
+        }
     }
 }

--- a/gravitee-node-container/src/test/java/io/gravitee/node/container/spring/env/WatchablePropertyResolverSubscriberTest.java
+++ b/gravitee-node-container/src/test/java/io/gravitee/node/container/spring/env/WatchablePropertyResolverSubscriberTest.java
@@ -1,0 +1,29 @@
+package io.gravitee.node.container.spring.env;
+
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Supplier;
+import io.reactivex.rxjava3.schedulers.TestScheduler;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class WatchablePropertyResolverSubscriberTest {
+
+    @Test
+    public void shouldRepeatFlowableWhenItsCompleted() {
+        int secondsDelay = 1;
+        TestScheduler testScheduler = new TestScheduler();
+
+        Supplier<Flowable<String>> flowableSupplier = () -> Flowable.just("1", "2");
+        TestSubscriber<String> test = new AbstractGraviteePropertySource.FlowableRepeater<>(flowableSupplier)
+            .repeatFlowable(secondsDelay, testScheduler)
+            .test();
+
+        testScheduler.advanceTimeBy(5, TimeUnit.SECONDS);
+        test.assertNotComplete();
+        test.assertValueCount(10);
+        testScheduler.advanceTimeBy(3, TimeUnit.SECONDS);
+        test.assertValueCount(16);
+        test.assertNotComplete();
+    }
+}


### PR DESCRIPTION
continue of AM-3317. 
Added one second delay to avoid log flooding in case of invalid  kubernetes:// yaml property.


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.18.2-AM-3317-fix-stackoverflow-ex-on-watch-loop-2-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.18.2-AM-3317-fix-stackoverflow-ex-on-watch-loop-2-SNAPSHOT/gravitee-node-5.18.2-AM-3317-fix-stackoverflow-ex-on-watch-loop-2-SNAPSHOT.zip)
  <!-- Version placeholder end -->
