### PR TITLE
Improve upgrader framework

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/Upgrader.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/Upgrader.java
@@ -24,4 +24,16 @@ public interface Upgrader {
     boolean upgrade();
 
     int getOrder();
+
+    default String version() {
+        return null;
+    }
+
+    default String identifier() {
+        String className = getClass().getName();
+        if (version() != null) {
+            return className + "_" + version();
+        }
+        return className;
+    }
 }

--- a/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/UpgraderServiceImpl.java
+++ b/gravitee-node-services/gravitee-node-services-upgrader/src/main/java/io/gravitee/node/services/upgrader/UpgraderServiceImpl.java
@@ -67,13 +67,13 @@ public class UpgraderServiceImpl extends AbstractService<UpgraderServiceImpl> im
             .forEach(upgrader -> {
                 String name = upgrader.getClass().getSimpleName();
                 try {
-                    UpgradeRecord upgradeRecord = upgraderRepository.findById(upgrader.getClass().getName()).blockingGet();
+                    UpgradeRecord upgradeRecord = upgraderRepository.findById(upgrader.identifier()).blockingGet();
                     if (upgradeRecord != null) {
                         LOGGER.info("{} is already applied. it will be ignored.", name);
                     } else {
                         LOGGER.info("Apply {} ...", name);
                         if (upgrader.upgrade()) {
-                            upgraderRepository.create(new UpgradeRecord(upgrader.getClass().getName(), new Date())).blockingGet();
+                            upgraderRepository.create(new UpgradeRecord(upgrader.identifier(), new Date())).blockingGet();
                         } else {
                             stopUpgrade.set(true);
                         }


### PR DESCRIPTION
**Issue**

N/A

**Description**

Improve upgrader framework to allow specifying a version and a name.

Versioning upgraders allow us to modify or fix them if required. By doing this, new versions of upgraders can be executed.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.8.7-update-upgrader-fwk-to-customize-upgrader-name-4-8-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.8.7-update-upgrader-fwk-to-customize-upgrader-name-4-8-x-SNAPSHOT/gravitee-node-4.8.7-update-upgrader-fwk-to-customize-upgrader-name-4-8-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
