### PR TITLE
feat: add AM enterprise certificate AWS plugin

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -88,6 +88,7 @@ packs:
         features:
             - gravitee-en-secretprovider-vault
             - gravitee-en-secretprovider-aws
+            - am-certificate-aws
     enterprise-alert-engine:
         features:
             - alert-engine

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -337,6 +337,7 @@ class DefaultLicenseFactoryTest {
             "am-resource-http",
             "gravitee-en-secretprovider-vault",
             "gravitee-en-secretprovider-aws",
+            "am-certificate-aws",
             "apim-policy-graphql-ratelimit",
             "apim-policy-interops-a-idp",
             "apim-policy-interops-r-idp",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AM-3310

**Description**

Add am-certificate-aws to licence model

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.19.0-feat-AM-3308-add-aws-am-certificate-plugin-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.19.0-feat-AM-3308-add-aws-am-certificate-plugin-SNAPSHOT/gravitee-node-5.19.0-feat-AM-3308-add-aws-am-certificate-plugin-SNAPSHOT.zip)
  <!-- Version placeholder end -->
