### PR TITLE
feat: allow to unregister a management endpoint

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/endpoint/ManagementEndpointManager.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/endpoint/ManagementEndpointManager.java
@@ -30,6 +30,13 @@ public interface ManagementEndpointManager {
      * @param listener the listener that will be called each time a management endpoint is registered.
      */
     void onEndpointRegistered(Consumer<ManagementEndpoint> listener);
+    /**
+     * Register a listener that will be called each time a management endpoint is unregistered.
+     * If endpoints are unregister before the listener, the listener won't be notified.
+     *
+     * @param listener the listener that will be called each time a management endpoint is registered.
+     */
+    void onEndpointUnregistered(Consumer<ManagementEndpoint> listener);
 
     /**
      * Register a new management endpoint. The endpoint will be immediately propagated to all the registered listeners.
@@ -37,4 +44,11 @@ public interface ManagementEndpointManager {
      * @param endpoint the endpoint to register
      */
     void register(ManagementEndpoint endpoint);
+
+    /**
+     * Register a new management endpoint. The endpoint will be immediately propagated to all the registered listeners.
+     *
+     * @param endpoint the endpoint to register
+     */
+    void unregister(ManagementEndpoint endpoint);
 }

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/verticle/ManagementVerticle.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/verticle/ManagementVerticle.java
@@ -166,6 +166,7 @@ public class ManagementVerticle extends AbstractVerticle {
                 } else {
                     // Listen to the endpoint manager to set up route when a management endpoint is registered.
                     managementEndpointManager.onEndpointRegistered(this::setupRoute);
+                    managementEndpointManager.onEndpointUnregistered(this::removeRoute);
 
                     // Register some default endpoints.
                     managementEndpointManager.register(nodeEndpoint);
@@ -212,6 +213,21 @@ public class ManagementVerticle extends AbstractVerticle {
             nodeWebhookRouter.route(convert(endpoint.method()), endpoint.path()).handler(endpoint::handle);
         } else {
             nodeRouter.route(convert(endpoint.method()), endpoint.path()).handler(endpoint::handle);
+        }
+    }
+
+    private void removeRoute(ManagementEndpoint endpoint) {
+        LOGGER.info(
+            "Unregister an endpoint for Management API: {} {} [{}]",
+            endpoint.method(),
+            endpoint.path(),
+            endpoint.getClass().getName()
+        );
+
+        if (endpoint.isWebhook()) {
+            nodeWebhookRouter.route(convert(endpoint.method()), endpoint.path()).remove();
+        } else {
+            nodeRouter.route(convert(endpoint.method()), endpoint.path()).remove();
         }
     }
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-389

**Description**

This PR add the capacity of unregistering a management endpoint.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.20.0-archi-389-allow-to-unregister-management-endpoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.20.0-archi-389-allow-to-unregister-management-endpoint-SNAPSHOT/gravitee-node-5.20.0-archi-389-allow-to-unregister-management-endpoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
