### PR TITLE
fix: NPE using rxPut and rxCompute

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,67 +1,107 @@
-
 = Gravitee-io - Node
 
-image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/graviteeio-node/blob/master/LICENSE.txt"]
-image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/graviteeio-node/releases"]
-image:https://circleci.com/gh/gravitee-io/gravitee-node.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-node"]
-image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
-
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License",link="https://github.com/gravitee-io/graviteeio-node/blob/master/LICENSE.txt"]
+image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases",link="https://github.com/gravitee-io/graviteeio-node/releases"]
+image:https://circleci.com/gh/gravitee-io/gravitee-node.svg?style=svg["CircleCI",link="https://circleci.com/gh/gravitee-io/gravitee-node"]
+image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum",link="https://community.gravitee.io?utm_source=readme", height=20]
 
 == Description
-The Gravitee.io node project is the cornerstone of every Gravitee.io product. It offers a piece of functionalities that can be selectively used out-of-the-box in a standard way.
+
+The Gravitee.io node project is the cornerstone of every Gravitee.io product.
+It offers a piece of functionalities that can be selectively used out-of-the-box in a standard way.
 
 == Modules
+
 === Api
+
 The Gravitee Node Api module regroups all the interfaces that are implemented in the other modules.
 
 === Cache
+
 The Gravitee Node Cache module regroups all the classes related to cache management plugins, and two plugins implementations: standalone and hazelcast.
 
 === Certificates
-The Gravitee Node Certificates module defines implementations useful to deal with SSL. For example, it provides based implementations allowing to load keystore from the file system or initialize a keystore with a self-signed certificate. Other node modules depend on it.
+
+The Gravitee Node Certificates module defines implementations useful to deal with SSL.
+For example, it provides based implementations allowing to load keystore from the file system or initialize a keystore with a self-signed certificate.
+Other node modules depend on it.
 
 === Cluster
+
 The Gravitee Node Cluster module regroups all the classes related to cluster management plugins, and two plugins implementations: standalone and hazelcast.
 
 === Jetty
-The Gravitee Node Jetty module gives an easy way to configure and start a Jetty server. Most of the Gravitee products rely on the node jetty module to set up and start an HTTP server and expose a REST api.
+
+The Gravitee Node Jetty module gives an easy way to configure and start a Jetty server.
+Most of the Gravitee products rely on the node jetty module to set up and start an HTTP server and expose a REST api.
 
 === Kubernetes
+
 The Gravitee Node Kubernetes module offers useful implementations that work natively with k8s such as loading a keystore from a Kubernetes secret or resolving configuration entries from configmap.
 
 === License
-The Gravitee Node License module provides an out-of-the-box feature allowing the detection and loading of a license key. It offers common access to license information. Many enterprise plugins are relying on it.
+
+The Gravitee Node License module provides an out-of-the-box feature allowing the detection and loading of a license key.
+It offers common access to license information.
+Many enterprise plugins are relying on it.
 
 === Management
-The Gravitee Node Management module allows exposing a management HTTP server that exposes product information (ex: node info, Prometheus metrics, …). It is also extensible as each product can expose its own set of endpoints.
+
+The Gravitee Node Management module allows exposing a management HTTP server that exposes product information (ex: node info, Prometheus metrics, …).
+It is also extensible as each product can expose its own set of endpoints.
 
 === Monitoring
-The Gravitee Node Monitoring module is responsible to set up a background task to collect monitoring information regularly. It also relies on the management module to expose an health HTTP endpoint that can be used in a common way to detect the unavailability of a node instance.
+
+The Gravitee Node Monitoring module is responsible to set up a background task to collect monitoring information regularly.
+It also relies on the management module to expose an health HTTP endpoint that can be used in a common way to detect the unavailability of a node instance.
 
 === Notifier
-The Gravitee Node Monitoring module offers a notification service that can be used by the different products to build an advanced notification system (ex: notify that a certificate is about to expire). It seamlessly works with any notifier plugin (slack, email, …).
+
+The Gravitee Node Monitoring module offers a notification service that can be used by the different products to build an advanced notification system (ex: notify that a certificate is about to expire).
+It seamlessly works with any notifier plugin (slack, email, …).
 
 === Plugins
+
 The Gravitee Node Plugins module contains internal code used to load and register services during the node startup phase.
 
 === Reporter
-The Gravitee Node Monitoring module is in charge of detecting and registering all reporter plugins. It exposes a reporter service that can be used as a single point-of-report by the Gravitee products. Internally, all events reported are propagated to each registered reporter.
+
+The Gravitee Node Monitoring module is in charge of detecting and registering all reporter plugins.
+It exposes a reporter service that can be used as a single point-of-report by the Gravitee products.
+Internally, all events reported are propagated to each registered reporter.
 
 === Services
-The Gravitee Node Services module provides different services such as upgrader and initializer services. They are particularly useful to ensure data migration during product upgrades or data initialization during the startup phase.
+
+The Gravitee Node Services module provides different services such as upgrader and initializer services.
+They are particularly useful to ensure data migration during product upgrades or data initialization during the startup phase.
 
 === Secrets
-The Gravitee Node Secrets module is about accessing secret managers. It is able to resolve secrets and certificates/private key. It use `secret-provider` plugins and manages their lifecycles as well as bundles a service to access secret using URL-like syntax: `secret://kubernetes...` used in gravitee.yml or equivalent environment variable.
+
+The Gravitee Node Secrets module is about accessing secret managers.
+It is able to resolve secrets and certificates/private key.
+It use `secret-provider` plugins and manages their lifecycles as well as bundles a service to access secret using URL-like syntax: `secret://kubernetes...` used in gravitee.yml or equivalent environment variable.
 
 === Tracing
-The Gravitee Node Services module gives an easy and common way to set up tracing (aka open telemetry) on a given product. It is able to automatically load and configure tracing plugin.
+
+The Gravitee Node Services module gives an easy and common way to set up tracing (aka open telemetry) on a given product.
+It is able to automatically load and configure tracing plugin.
 
 === Vertx
+
 The Gravitee Node Vertx module is a common piece of Gravitee products that offers the capabilities to set up vertx and instantiate vertx http servers easily.
 
 == Releases
 
+=== 6.0.x
+
+The following has been implemented on v6.0.x
+
+==== Changelog
+
+* BREAKING CHANGE: fix switch cache rxPut and rxCompute methods to Maybe instead of Single
+
 === 5.3.x
+
 The following has been implemented on v5.3.x
 
 ==== Changelog
@@ -70,9 +110,12 @@ The following has been implemented on v5.3.x
 
 ===== Migrating to node v5.3.0
 
- * Update `gravitee-node` to 5.3.0 and `gravitee-plugin` to 3.0.0
- * Remove Spring imports related to the plugin's configuration. Usually, the plugin configuration classes are named `XXXPluginConfiguration`. They are not necessary anymore as they are now directly added by the plugin handler.
- * `SpringBasedContainer` requires the node implementation class to be passed to the constructor. Ex:
+* Update `gravitee-node` to 5.3.0 and `gravitee-plugin` to 3.0.0
+* Remove Spring imports related to the plugin's configuration.
+Usually, the plugin configuration classes are named `XXXPluginConfiguration`.
+They are not necessary anymore as they are now directly added by the plugin handler.
+* `SpringBasedContainer` requires the node implementation class to be passed to the constructor.
+Ex:
 
 ```java
 public class GatewayContainer extends SpringBasedContainer {
@@ -84,7 +127,8 @@ public class GatewayContainer extends SpringBasedContainer {
 }
 ```
 
- * Add `@Lazy` on any application bean required by the Node implementation class. Ex:
+* Add `@Lazy` on any application bean required by the Node implementation class.
+Ex:
 
 ```java
 public class GatewayNode extends AbstractNode {
@@ -96,28 +140,34 @@ public class GatewayNode extends AbstractNode {
 }
 ```
 
- * Remove `EventManager` bean because it is now created by default.
- * Remove `ClusterManager` bean because it is now created by default.
+* Remove `EventManager` bean because it is now created by default.
+* Remove `ClusterManager` bean because it is now created by default.
 
-IMPORTANT: `gravitee-node` previous behavior was to just log and continue the startup in case of an error during plugin initialization. *The new behavior is to rethrow the error and stop the startup*. It makes it clearer and helps in debugging.
+IMPORTANT: `gravitee-node` previous behavior was to just log and continue the startup in case of an error during plugin initialization. *The new behavior is to rethrow the error and stop the startup*.
+It makes it clearer and helps in debugging.
 
 === 5.0.x
+
 The following has been implemented on v5.0.x
 
 ==== Changelog
 
- * Add support for organization license
- * Update keystore loading internal and support for truststore hot reload
+* Add support for organization license
+* Update keystore loading internal and support for truststore hot reload
 
 ==== LicenseManager migration
 
-Framework now offers support for both platform and organization licenses. Here are some highlights of the main changes:
+Framework now offers support for both platform and organization licenses.
+Here are some highlights of the main changes:
 
- * No more `Node.license()` → use LicenseManager.getPlatformLicense() instead
- * Platform license is never null. If no license key is specified by the user, an OSS license with no feature and no expiry will be considered.
- * Any product that needs to support the license at the organization level can implement the repository layer implementing the `LicenseRepository` interface and the appropriate synchronizer.
- * `LicenseService` no longer exists. Loading the platform license is now achieved by `NodeLicenseLoader`. Customers who have changed the log level on `io.gravitee.node.license.LicenseService` to avoid logging license information must adapt their `logback.xml` configuration to use `io.gravitee.node.license.LicenseLoaderService` instead.
- * Technical API allows access to the platform license which previously ended with a 404 if the license key is not specified → OSS License will now be returned instead.
+* No more `Node.license()` → use LicenseManager.getPlatformLicense() instead
+* Platform license is never null.
+If no license key is specified by the user, an OSS license with no feature and no expiry will be considered.
+* Any product that needs to support the license at the organization level can implement the repository layer implementing the `LicenseRepository` interface and the appropriate synchronizer.
+* `LicenseService` no longer exists.
+Loading the platform license is now achieved by `NodeLicenseLoader`.
+Customers who have changed the log level on `io.gravitee.node.license.LicenseService` to avoid logging license information must adapt their `logback.xml` configuration to use `io.gravitee.node.license.LicenseLoaderService` instead.
+* Technical API allows access to the platform license which previously ended with a 404 if the license key is not specified → OSS License will now be returned instead.
 
 ==== Truststore hot reload
 
@@ -127,94 +177,108 @@ Any kind of truststore JKS (deprecated format), PKCS12, pem files and pem-folder
 * Truststore file can be replaced by simple copy override
 * Same for pem certificates in the list (type: pem with a list file as an array)
 
-New type of truststore: `pem-folder` allow users to specify via `path: /path/to/certs` a directory that will be watched for new pem certificates files. Those certificates will be added to the truststore. Updates and removal are also supported. Note that recursive sub-directory listing will not occur.
+New type of truststore: `pem-folder` allow users to specify via `path: /path/to/certs` a directory that will be watched for new pem certificates files.
+Those certificates will be added to the truststore.
+Updates and removal are also supported.
+Note that recursive sub-directory listing will not occur.
 
 === 4.0.x
+
 The following has been implemented on v4.0.x
 
 ==== Changelog
- * Add support for multi-servers
- * Move cluster concept into plugins
- * Move cache concept into plugins
- * Add support for Secret Managers via new secret-provider plugin type
+
+* Add support for multi-servers
+* Move cluster concept into plugins
+* Move cache concept into plugins
+* Add support for Secret Managers via new secret-provider plugin type
 
 ==== Vertx Http Server migration
-The readme provides all details regarding the usage of the VertxServerFactory. Here are some highlights of the main changes:
 
- * The package has changed for the `VertxHttpServerFactory` use `io.gravitee.node.vertx.server.http.VertxHttpServerFactory`
- * `HttpServerConfiguration` has been replaced with `io.gravitee.node.vertx.server.http.HttpServerOptions` which now provides a regular `builder()` method allowing configuring the server.
- * `HttpServerOptions` builder can be initialized using the environment configuration. Then, any configuration can be overridden.
+The readme provides all details regarding the usage of the VertxServerFactory.
+Here are some highlights of the main changes:
+
+* The package has changed for the `VertxHttpServerFactory` use `io.gravitee.node.vertx.server.http.VertxHttpServerFactory`
+* `HttpServerConfiguration` has been replaced with `io.gravitee.node.vertx.server.http.HttpServerOptions` which now provides a regular `builder()` method allowing configuring the server.
+* `HttpServerOptions` builder can be initialized using the environment configuration.
+Then, any configuration can be overridden.
 
 ==== New cluster manager migration
-Cluster Managers are now available via plugins. Default distribution contains a Standalone Cluster Manager which was and still is the default one.
+
+Cluster Managers are now available via plugins.
+Default distribution contains a Standalone Cluster Manager which was and still is the default one.
 
 Two plugins are available :
 
- * Standalone Cluster Manager which is the default plugin. This plugin is used when no cluster is configured, i.e. each node is alone in its own cluster.
- * Hazelcast Cluster Manager which has to be added to the distribution and enable by setting `cluster.type` to _hazelcast_.
+* Standalone Cluster Manager which is the default plugin.
+This plugin is used when no cluster is configured, i.e. each node is alone in its own cluster.
+* Hazelcast Cluster Manager which has to be added to the distribution and enable by setting `cluster.type` to _hazelcast_.
 
 Interfaces have slightly changed, here are the details for each:
 
 __ClusterManager__
 
 * Methods changed
-  - `getMembers()` has been renamed to `members()`
-  - `getLocalMember()` has been renamed to `localMember()`
-  - `isMasterNode()` has been renamed to `isPrimaryNode()`
+- `getMembers()` has been renamed to `members()`
+- `getLocalMember()` has been renamed to `localMember()`
+- `isMasterNode()` has been renamed to `isPrimaryNode()`
 * Method added
-  - `removeMemberListener(MemberListener)`  allows to remove a previously registered listener
-  - `topic(String)` replace the old `MessageProducer` bean which has been removed and allows retrieval of a topic from its name
+- `removeMemberListener(MemberListener)`  allows to remove a previously registered listener
+- `topic(String)` replace the old `MessageProducer` bean which has been removed and allows retrieval of a topic from its name
 
 __MemberListener__
 
-  * `memberAdded(Member)` has been renamed to `onMemberAdded(Member)`
-  * `memberRemoved(Member)` has been renamed to `onMemberRemoved(Member)`
-  * `memberChanged(Member)` has been renamed to `onMemberChanged(Member)`
+* `memberAdded(Member)` has been renamed to `onMemberAdded(Member)`
+* `memberRemoved(Member)` has been renamed to `onMemberRemoved(Member)`
+* `memberChanged(Member)` has been renamed to `onMemberChanged(Member)`
 
 __Member__
 
-  * Methods changed
-    - `uuid()` has been renamed to `id()`
-    - `master()` has been renamed to primary()`
-  * Method added
-    - `local` which returns true if the associated member is the local one
+* Methods changed
+- `uuid()` has been renamed to `id()`
+- `master()` has been renamed to primary()`
+* Method added
+- `local` which returns true if the associated member is the local one
 
 __MessageProducer__
 
-  * Has been removed and replaced by topic method in ClusterManager.
+* Has been removed and replaced by topic method in ClusterManager.
 
 __Topic__
 
-  * Has been moved from `io.gravitee.node.api.message to io.gravitee.node.api.cluster.messaging`.
-  * The use of UUID has been replaced by `String`
+* Has been moved from `io.gravitee.node.api.message to io.gravitee.node.api.cluster.messaging`.
+* The use of UUID has been replaced by `String`
 
 __Message__
 
-  * Has been moved from `io.gravitee.node.api.message to io.gravitee.node.api.cluster.messaging`.
+* Has been moved from `io.gravitee.node.api.message to io.gravitee.node.api.cluster.messaging`.
 
 __MessageConsumer__
 
-  * Has been renamed to `MessageListener` and moved to `io.gravitee.node.api.cluster.messaging`.
-
+* Has been renamed to `MessageListener` and moved to `io.gravitee.node.api.cluster.messaging`.
 
 ==== New cache manager migration
-Cache Managers are now available via plugins. Default distribution contains a Standalone Cache Manager which was and still is the default one.
+
+Cache Managers are now available via plugins.
+Default distribution contains a Standalone Cache Manager which was and still is the default one.
 
 Two plugins are available :
 
-* Standalone Cache Manager which is the default plugin. The cache will not be distributed and will always remain local to the node (in-memory).
-* Hazelcast Cache Manager which has to be added to the distribution and enable by setting `cache.type` to `hazelcast`. With this plugin the cache could be either local (in-memory) or distributed (Hazelcast IMap).
+* Standalone Cache Manager which is the default plugin.
+The cache will not be distributed and will always remain local to the node (in-memory).
+* Hazelcast Cache Manager which has to be added to the distribution and enable by setting `cache.type` to `hazelcast`.
+With this plugin the cache could be either local (in-memory) or distributed (Hazelcast IMap).
 
 Following changes have been introduced:
 
- * Ability to define the scope of the cache (local or distributed) by using new `CacheConfiguration#distributed` attribute
- * Replace Guava Cache by Caffeine
-
+* Ability to define the scope of the cache (local or distributed) by using new `CacheConfiguration#distributed` attribute
+* Replace Guava Cache by Caffeine
 
 ==== Support for Secret Managers
 
 Secret Mangers can be used in Gravitee Gateways using gravitee-node.
-Secret providers plugins can pull or watch secrets from Secret Managers (eg. Kubernetes, HC Vault...) using associated plugins.
+Secret providers plugins can pull or watch secrets from Secret Managers (eg.
+Kubernetes, HC Vault...) using associated plugins.
 
 `gravitee.yml` contains configuration to set up secret managers, note that they can be configured using env variables.
 This is an example with community bundle plugin `kubernetes-secret-provider`:
@@ -233,6 +297,7 @@ ratelimit:
     password: secret://kubernetes/redis-secret:password
     # ...
 ----
+
 `GRAVITEEIO_SECRETS_KUBERNETES_ENABLED=true` would be enough to resolve secrets within the same namespace where gravitee is deployed.
 
 You can also use a secret provider to configure another secret provider:

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/Cache.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/Cache.java
@@ -32,107 +32,317 @@ import java.util.function.Function;
  * @author GraviteeSource Team
  */
 public interface Cache<K, V> {
+    /**
+     * Get the name of this cache.
+     *
+     * @return the name if this cache.
+     */
     String getName();
 
+    /**
+     * Get a collection of all the values in this cache.
+     *
+     * @return a collection of all the values in the cache.
+     */
     Collection<V> values();
 
+    /**
+     * Reactive method to get all the values in this cache as a <code>Flowable</code>.
+     *
+     * @return a <code>Flowable</code> containing all the values in the cache.
+     */
     default Flowable<V> rxValues() {
         return Flowable.fromIterable(this.values()).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Get a set of all the keys in this cache.
+     *
+     * @return a set of all the keys in the cache.
+     */
     Set<K> keys();
 
+    /**
+     * Reactive method to get all the keys in this cache as a <code>Flowable</code>.
+     *
+     * @return a <code>Flowable</code> containing all the keys in the cache.
+     */
     default Flowable<K> rxKeys() {
         return Flowable.fromIterable(this.keys()).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Get set of all the entries in the cache.
+     *
+     * @return all the entries in the cache.
+     */
     Set<Map.Entry<K, V>> entrySet();
 
+    /**
+     * Reactive method to get all the entries in this cache as a <code>Flowable</code>.
+     *
+     * @return a <code>Flowable</code> containing all the entries in the cache.
+     */
     default Flowable<Map.Entry<K, V>> rxEntrySet() {
         return Flowable.fromIterable(this.entrySet()).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Get the current size of this cache.
+     *
+     * @return the size of the cache.
+     */
     int size();
 
+    /**
+     * Reactive method to get the current size of this cache.
+     *
+     * @return a <code>Single</code> containing the size of the cache.
+     */
     default Single<Integer> rxSize() {
         return Single.fromCallable(this::size).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Check if this cache is empty.
+     *
+     * @return <code>true</code> if the cache is empty, <code>false</code> otherwise.
+     */
     boolean isEmpty();
 
+    /**
+     * Reactive method to check if this cache is empty.
+     *
+     * @return a <code>Single<code> containing <code>true</code> if the cache is empty, <code>false</code> otherwise.
+     */
     default Single<Boolean> rxIsEmpty() {
         return Single.fromCallable(this::isEmpty).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Check if the specified key is in this cache.
+     * @param key the key.
+     *
+     * @return <code>true</code> if the key is in the cache, <code>false</code> otherwise.
+     */
     boolean containsKey(final K key);
 
+    /**
+     * Reactive method to check if the specified key is in this cache.
+     * @param key the key.
+     *
+     * @return a <code>Single<code> containing <code>true</code> if the key is in the cache, <code>false</code> otherwise.
+     */
     default Single<Boolean> rxContainsKey(final K key) {
         return Single.fromCallable(() -> this.containsKey(key)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Return the value for the specified key or <code>null</code> if this cache does not contain this key.
+     * @param key the key used to get the value.
+     *
+     * @return the value or <code>null</code> if no value has been found.
+     */
     V get(final K key);
 
+    /**
+     * Reactive method to get the value for the specified key as a <code>Maybe</code>. An empty <code>Maybe</code> is returned if this cache does not contain this key.
+     * @param key the key used to get the value.
+     *
+     * @return a <code>Maybe</code> containing the value or an empty <code>Maybe</code> if no value has been found.
+     */
     default Maybe<V> rxGet(final K key) {
         return Maybe.fromCallable(() -> this.get(key)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Associate the value to the specified key in this cache and returns the previous value that was associated to this key or <code>null</code>
+     * if no value was previously associated to this key.
+     * @param key the key.
+     * @param value the value.
+     *
+     * @return the previous value associated to the specified key or <code>null</code> if no value was present.
+     */
     V put(final K key, final V value);
 
-    default Single<V> rxPut(final K key, final V value) {
-        return Single.fromCallable(() -> this.put(key, value)).subscribeOn(Schedulers.io());
+    /**
+     * Reactive method to associate the value to the specified key in this cache and return a <code>Maybe</code> containing the previous value that was associated to this key.
+     * An empty <code>Maybe</code> is returned if no value was previously associated to this key.
+     * @param key the key.
+     * @param value the value.
+     *
+     * @return a <code>Maybe</code> containing the previous value or an empty <code>Maybe</code> if no value was present.
+     */
+    default Maybe<V> rxPut(final K key, final V value) {
+        return Maybe.fromCallable(() -> this.put(key, value)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Same as {@link #put(Object, Object)} but with a time to live.
+     * @param key the key.
+     * @param value the value.
+     *
+     * @return the previous value associated to the specified key or <code>null</code> if no value was present.
+     */
     V put(final K key, final V value, final long ttl, final TimeUnit ttlUnit);
 
-    default Single<V> rxPut(final K key, final V value, final long ttl, final TimeUnit ttlUnit) {
-        return Single.fromCallable(() -> this.put(key, value, ttl, ttlUnit)).subscribeOn(Schedulers.io());
+    /**
+     * Same as {@link #rxPut(Object, Object)} but with a time to live.
+     * @param key the key.
+     * @param value the value.
+     *
+     * @return the previous value associated to the specified key or <code>null</code> if no value was present.
+     */
+    default Maybe<V> rxPut(final K key, final V value, final long ttl, final TimeUnit ttlUnit) {
+        return Maybe.fromCallable(() -> this.put(key, value, ttl, ttlUnit)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Put all the specified key/value pairs into this cache.
+     * @param m a map containing all the key/value pairs to put into this cache.
+     */
     void putAll(final Map<? extends K, ? extends V> m);
 
+    /**
+     * Reactive method to put all the specified key/value pairs into this cache.
+     * @param m a map containing all the key/value pairs to put into this cache.
+     *
+     * @return a <code>Completable</code> that completes once all the key/value pairs have been put in the cache.
+     */
     default Completable rxPutAll(final Map<? extends K, ? extends V> m) {
         return Completable.fromRunnable(() -> this.putAll(m)).subscribeOn(Schedulers.io());
     }
 
-    V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction);
+    /**
+     * If the specified key is not already associated with a value, attempt to compute the value of the specified key using the given remapping function.
+     * If the remapping function returns <code>null</code>, the mapping is removed.
+     * @param key the key.
+     * @param remappingFunction the function that is executed to associate the new value in case no value was present.
+     *
+     * @return the computed value if it was absent (<code>null</code> if the mapping function returns <code>null</code>) or the existing one if it was already present.
+     */
+    V computeIfAbsent(K key, Function<? super K, ? extends V> remappingFunction);
 
-    default Single<V> rxComputeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
-        return Single.fromCallable(() -> this.computeIfAbsent(key, mappingFunction)).subscribeOn(Schedulers.io());
+    /**
+     * Reactive method to compute the value of the specified key using the given mapping function if it is not already associated with a value.
+     * If the remapping function returns <code>null</code>, the mapping is removed.
+     * @param key the key.
+     * @param mappingFunction the function that is executed to associate the new value in case no value was present.
+     *
+     * @return a <code>Maybe</code> containing the computed value if it was absent (empty if the mapping function returns <code>null</code>) or the existing one if it was already present.
+     */
+    default Maybe<V> rxComputeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        return Maybe.fromCallable(() -> this.computeIfAbsent(key, mappingFunction)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * If the specified key is already associated with a value, attempt to compute the value of the specified key using the given mapping function.
+     * If the remapping function returns <code>null</code>, the mapping is removed.
+     * @param key the key.
+     * @param remappingFunction the function that is executed to associate the new value in case a value was present.
+     *
+     * @return the computed value (<code>null</code> if the mapping function returns <code>null</code>).
+     */
     V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction);
 
-    default Single<V> rxComputeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-        return Single.fromCallable(() -> this.computeIfPresent(key, remappingFunction)).subscribeOn(Schedulers.io());
+    /**
+     * Reactive method to compute the value of the specified key using the given mapping function if it is already associated with a value.
+     * If the remapping function returns <code>null</code>, the mapping is removed.
+     * @param key the key.
+     * @param remappingFunction the function that is executed to associate the new value in case a value was present.
+     *
+     * @return a <code>Maybe</code> containing the computed value (empty if the mapping function returns <code>null</code>).
+     */
+    default Maybe<V> rxComputeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return Maybe.fromCallable(() -> this.computeIfPresent(key, remappingFunction)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Compute the value of the specified key using the given mapping function.
+     * If the remapping function returns <code>null</code>, the mapping is removed.
+     * @param key the key.
+     * @param remappingFunction the function that is executed to associate the new value.
+     *
+     * @return the computed value (<code>null</code> if the mapping function returns <code>null</code>).
+     */
     V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction);
 
-    default Single<V> rxCompute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
-        return Single.fromCallable(() -> this.compute(key, remappingFunction)).subscribeOn(Schedulers.io());
+    /**
+     * Reactive method to compute the value of the specified key using the given mapping function.
+     * @param key the key.
+     * @param remappingFunction the function that is executed to associate the new value.
+     *
+     * @return a <code>Maybe</code> containing the computed value (empty one if the mapping function returns <code>null</code>).
+     */
+    default Maybe<V> rxCompute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        return Maybe.fromCallable(() -> this.compute(key, remappingFunction)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Remove the key/value entry from the cache.
+     * @param key the key.
+     *
+     * @return the remove value or <code>null</code> if it wasn't present.
+     */
     V evict(final K key);
 
-    default Single<V> rxEvict(final K key) {
-        return Single.fromCallable(() -> this.evict(key)).subscribeOn(Schedulers.io());
+    /**
+     * Reactive method to remove the key/value entry from the cache.
+     * @param key the key.
+     *
+     * @return a <code>Maybe</code> containing the removed value or an empty one if it wasn't present.
+     */
+    default Maybe<V> rxEvict(final K key) {
+        return Maybe.fromCallable(() -> this.evict(key)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Clear the cache.
+     */
     void clear();
 
+    /**
+     * Reactive method to clear the cache.
+     *
+     * @return a <code>Completable</code> that completes when the cache has been cleared.
+     */
     default Completable rxClear() {
         return Completable.fromRunnable(this::clear).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Add a listener that will be called on for each action on this cache.
+     * @param listener the cache listener.
+     *
+     * @return an uuid for this cache listener that can be used to remove this it.
+     */
     String addCacheListener(CacheListener<K, V> listener);
 
+    /**
+     * Reactive method to add a listener that will be called on for each action on this cache.
+     * @param listener the cache listener.
+     *
+     * @return a <code>Single</code> containing an uuid for this cache listener that can be used to remove this it.
+     */
     default Single<String> rxAddCacheListener(CacheListener<K, V> listener) {
         return Single.fromCallable(() -> this.addCacheListener(listener)).subscribeOn(Schedulers.io());
     }
 
+    /**
+     * Remove the specified cache listener.
+     * @param listenerCacheId the id of the cache listener to remove.
+     *
+     * @return <code>true</code> if the cache listener has been removed, <code>false</code> otherwise.
+     */
     boolean removeCacheListener(final String listenerCacheId);
 
-    default Completable rxRemoveCacheListener(final String listenerCacheId) {
-        return Completable.fromRunnable(() -> this.removeCacheListener(listenerCacheId)).subscribeOn(Schedulers.io());
+    /**
+     * Reactive method to remove the specified cache listener.
+     * @param listenerCacheId the id of the cache listener to remove.
+     *
+     * @return a <code>Single</code> containing <code>true</code> if the cache listener has been remove or <code>false</code> otherwise.
+     */
+    default Single<Boolean> rxRemoveCacheListener(final String listenerCacheId) {
+        return Single.fromCallable(() -> this.removeCacheListener(listenerCacheId)).subscribeOn(Schedulers.io());
     }
 }

--- a/gravitee-node-cache/gravitee-node-cache-common/src/test/java/io/gravitee/node/plugin/cache/common/InMemoryCacheTest.java
+++ b/gravitee-node-cache/gravitee-node-cache-common/src/test/java/io/gravitee/node/plugin/cache/common/InMemoryCacheTest.java
@@ -90,6 +90,52 @@ class InMemoryCacheTest {
     }
 
     @Nested
+    class RxGetTest {
+
+        @Test
+        void should_return_null_when_getting_non_existing_key() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxGet("no_key").blockingGet()).isNull();
+        }
+
+        @Test
+        void should_return_null_when_entry_expired() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, TEST_VALUE, 1, TimeUnit.MILLISECONDS);
+
+            await()
+                .pollInterval(10, TimeUnit.MILLISECONDS)
+                .atMost(100, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(cache.rxGet(TEST_KEY).blockingGet()).isNull();
+                    assertThat(cache.rxValues().blockingIterable()).isEmpty();
+                });
+        }
+
+        @Test
+        void should_return_no_values_when_no_entry_in_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxSize().blockingGet()).isZero();
+            assertThat(cache.rxValues().blockingIterable()).isEmpty();
+        }
+
+        @Test
+        void should_return_no_values_when_entry_expired() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, TEST_VALUE, 1, TimeUnit.MILLISECONDS);
+
+            await()
+                .pollInterval(10, TimeUnit.MILLISECONDS)
+                .atMost(100, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(cache.rxValues().blockingIterable()).isEmpty());
+        }
+    }
+
+    @Nested
     class PutTest {
 
         @Test
@@ -178,6 +224,96 @@ class InMemoryCacheTest {
     }
 
     @Nested
+    class RxPutTest {
+
+        @Test
+        void should_put_value_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxPut(TEST_KEY, TEST_VALUE).blockingGet()).isNull();
+
+            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+        }
+
+        @Test
+        void should_put_value_to_cache_and_expired_after_ttl() {
+            CacheConfiguration configuration = CacheConfiguration.builder().timeToLiveInMs(200).build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxPut(TEST_KEY, TEST_VALUE).blockingGet()).isNull();
+            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+
+            await()
+                .atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(cache.get(TEST_KEY)).isNull();
+                    assertThat(cache.values()).isEmpty();
+                });
+        }
+
+        @Test
+        void should_put_value_to_cache_with_custom_ttl_and_expired_after_ttl() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+
+            assertThat(cache.rxPut(TEST_KEY, TEST_VALUE, 200, TimeUnit.MILLISECONDS).blockingGet()).isNull();
+            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+
+            await()
+                .atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(cache.get(TEST_KEY)).isNull();
+                    assertThat(cache.values()).isEmpty();
+                });
+        }
+
+        @Test
+        void should_notify_listener_when_putting_new_value_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryAdded(final String key, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            assertThat(cache.rxPut(TEST_KEY, TEST_VALUE).blockingGet()).isNull();
+            await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertThat(listenerCalled).isTrue());
+        }
+
+        @Test
+        void should_notify_listener_when_putting_updated_value_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryUpdated(final String key, final String oldValue, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            assertThat(cache.rxPut(TEST_KEY, TEST_VALUE).blockingGet()).isNull();
+            assertThat(cache.rxPut(TEST_KEY, TEST_VALUE_UPDATED).blockingGet()).isEqualTo(TEST_VALUE);
+
+            await()
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(listenerCalled).isTrue();
+                });
+        }
+    }
+
+    @Nested
     class PutAllTest {
 
         @Test
@@ -252,6 +388,80 @@ class InMemoryCacheTest {
     }
 
     @Nested
+    class RxPutAllTest {
+
+        @Test
+        void should_put_all_values_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.rxPutAll(Map.of(TEST_KEY, TEST_VALUE, TEST_KEY2, TEST_VALUE2)).blockingAwait();
+
+            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.get(TEST_KEY2)).isNotNull();
+            assertThat(cache.values()).hasSize(2);
+            assertThat(cache.values()).containsOnly(TEST_VALUE, TEST_VALUE2);
+        }
+
+        @Test
+        void should_put_all_values_to_cache_and_expired_after_ttl() {
+            CacheConfiguration configuration = CacheConfiguration.builder().timeToLiveInMs(200).build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.rxPutAll(Map.of(TEST_KEY, TEST_VALUE, TEST_KEY2, TEST_VALUE2)).blockingAwait();
+            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.get(TEST_KEY2)).isNotNull();
+            assertThat(cache.values()).hasSize(2);
+            assertThat(cache.values()).containsOnly(TEST_VALUE, TEST_VALUE2);
+
+            await()
+                .atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(cache.get(TEST_KEY)).isNull();
+                    assertThat(cache.get(TEST_KEY2)).isNull();
+                    assertThat(cache.values()).isEmpty();
+                });
+        }
+
+        @Test
+        void should_notify_listener_when_putting_new_values_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryAdded(final String key, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            cache.rxPutAll(Map.of(TEST_KEY, TEST_VALUE, TEST_KEY2, TEST_VALUE2)).blockingAwait();
+            await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertThat(listenerCalled).isTrue());
+        }
+
+        @Test
+        void should_notify_listener_when_putting_updated_value_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryUpdated(final String key, final String oldValue, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            cache.rxPutAll(Map.of(TEST_KEY, TEST_VALUE, TEST_KEY2, TEST_VALUE2)).blockingAwait();
+            cache.rxPutAll(Map.of(TEST_KEY, TEST_VALUE_UPDATED)).blockingAwait();
+            await()
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(listenerCalled).isTrue();
+                });
+        }
+    }
+
+    @Nested
     class ComputeIfAbsentTest {
 
         @Test
@@ -259,18 +469,27 @@ class InMemoryCacheTest {
             CacheConfiguration configuration = CacheConfiguration.builder().build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
             cache.put(TEST_KEY, TEST_VALUE);
-            cache.computeIfAbsent(TEST_KEY, k -> "wrong value");
-            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.computeIfAbsent(TEST_KEY, k -> "wrong value")).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
             assertThat(cache.values()).hasSize(1);
             assertThat(cache.values()).containsOnly(TEST_VALUE);
+        }
+
+        @Test
+        void should_do_nothing_if_mapping_returns_null() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.computeIfAbsent(TEST_KEY, k -> null)).isNull();
+            assertThat(cache.get(TEST_KEY)).isNull();
+            assertThat(cache.values()).isEmpty();
         }
 
         @Test
         void should_computeIfAbsent_to_cache() {
             CacheConfiguration configuration = CacheConfiguration.builder().build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
-            cache.computeIfAbsent(TEST_KEY, k -> TEST_VALUE);
-            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.computeIfAbsent(TEST_KEY, k -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
             assertThat(cache.values()).hasSize(1);
             assertThat(cache.values()).containsOnly(TEST_VALUE);
         }
@@ -279,8 +498,8 @@ class InMemoryCacheTest {
         void should_computeIfAbsent_to_cache_and_expired_after_ttl() {
             CacheConfiguration configuration = CacheConfiguration.builder().timeToLiveInMs(200).build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
-            cache.computeIfAbsent(TEST_KEY, k -> TEST_VALUE);
-            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.computeIfAbsent(TEST_KEY, k -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
             assertThat(cache.values()).hasSize(1);
             assertThat(cache.values()).containsOnly(TEST_VALUE);
 
@@ -305,7 +524,75 @@ class InMemoryCacheTest {
                     }
                 }
             );
-            cache.computeIfAbsent(TEST_KEY, k -> TEST_VALUE);
+            assertThat(cache.computeIfAbsent(TEST_KEY, k -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertThat(listenerCalled).isTrue());
+        }
+    }
+
+    @Nested
+    class RxComputeIfAbsentTest {
+
+        @Test
+        void should_do_nothing_if_key_already_present_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, TEST_VALUE);
+            assertThat(cache.rxComputeIfAbsent(TEST_KEY, k -> "wrong value").blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+        }
+
+        @Test
+        void should_do_nothing_if_mapping_returns_null() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxComputeIfAbsent(TEST_KEY, k -> null).blockingGet()).isNull();
+            assertThat(cache.get(TEST_KEY)).isNull();
+            assertThat(cache.values()).isEmpty();
+        }
+
+        @Test
+        void should_computeIfAbsent_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxComputeIfAbsent(TEST_KEY, k -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+        }
+
+        @Test
+        void should_computeIfAbsent_to_cache_and_expired_after_ttl() {
+            CacheConfiguration configuration = CacheConfiguration.builder().timeToLiveInMs(200).build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxComputeIfAbsent(TEST_KEY, k -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+
+            await()
+                .atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(cache.get(TEST_KEY)).isNull();
+                    assertThat(cache.values()).isEmpty();
+                });
+        }
+
+        @Test
+        void should_notify_listener_when_computeIfAbsent_value_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryAdded(final String key, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            assertThat(cache.rxComputeIfAbsent(TEST_KEY, k -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
             await().atMost(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertThat(listenerCalled).isTrue());
         }
     }
@@ -317,7 +604,17 @@ class InMemoryCacheTest {
         void should_do_nothing_if_key_not_present_to_cache() {
             CacheConfiguration configuration = CacheConfiguration.builder().build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
-            cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE);
+            assertThat(cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE)).isNull();
+            assertThat(cache.get(TEST_KEY)).isNull();
+            assertThat(cache.values()).isEmpty();
+        }
+
+        @Test
+        void should_remove_if_mapping_returns_null() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, "wrong_value");
+            assertThat(cache.computeIfPresent(TEST_KEY, (k, v) -> null)).isNull();
             assertThat(cache.get(TEST_KEY)).isNull();
             assertThat(cache.values()).isEmpty();
         }
@@ -327,8 +624,8 @@ class InMemoryCacheTest {
             CacheConfiguration configuration = CacheConfiguration.builder().build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
             cache.put(TEST_KEY, "wrong_value");
-            cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE);
-            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
             assertThat(cache.values()).hasSize(1);
             assertThat(cache.values()).containsOnly(TEST_VALUE);
         }
@@ -338,8 +635,8 @@ class InMemoryCacheTest {
             CacheConfiguration configuration = CacheConfiguration.builder().timeToLiveInMs(200).build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
             cache.put(TEST_KEY, "wrong_value");
-            cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE);
-            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
             assertThat(cache.values()).hasSize(1);
             assertThat(cache.values()).containsOnly(TEST_VALUE);
 
@@ -365,8 +662,83 @@ class InMemoryCacheTest {
                 }
             );
             cache.put(TEST_KEY, "wrong_value");
-            cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE);
-            cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE_UPDATED);
+            assertThat(cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            assertThat(cache.computeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE_UPDATED)).isEqualTo(TEST_VALUE_UPDATED);
+            await()
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(listenerCalled).isTrue();
+                });
+        }
+    }
+
+    @Nested
+    class RxComputeIfPresentTest {
+
+        @Test
+        void should_do_nothing_if_key_not_present_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxComputeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isNull();
+            assertThat(cache.get(TEST_KEY)).isNull();
+            assertThat(cache.values()).isEmpty();
+        }
+
+        @Test
+        void should_remove_if_mapping_returns_null() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, "wrong_value");
+            assertThat(cache.rxComputeIfPresent(TEST_KEY, (k, v) -> null).blockingGet()).isNull();
+            assertThat(cache.get(TEST_KEY)).isNull();
+            assertThat(cache.values()).isEmpty();
+        }
+
+        @Test
+        void should_computeIfPresent_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, "wrong_value");
+            assertThat(cache.rxComputeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+        }
+
+        @Test
+        void should_computeIfPresent_to_cache_and_expired_after_ttl() {
+            CacheConfiguration configuration = CacheConfiguration.builder().timeToLiveInMs(200).build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, "wrong_value");
+            assertThat(cache.rxComputeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+
+            await()
+                .atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(cache.get(TEST_KEY)).isNull();
+                    assertThat(cache.values()).isEmpty();
+                });
+        }
+
+        @Test
+        void should_notify_listener_when_computeIfPresent_updated_value_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryUpdated(final String key, final String oldValue, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            cache.put(TEST_KEY, "wrong_value");
+            assertThat(cache.rxComputeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.rxComputeIfPresent(TEST_KEY, (k, v) -> TEST_VALUE_UPDATED).blockingGet()).isEqualTo(TEST_VALUE_UPDATED);
             await()
                 .atMost(500, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
@@ -382,10 +754,20 @@ class InMemoryCacheTest {
         void should_compute_if_no_key_present_to_cache() {
             CacheConfiguration configuration = CacheConfiguration.builder().build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
-            cache.compute(TEST_KEY, (k, v) -> TEST_VALUE);
+            assertThat(cache.compute(TEST_KEY, (k, v) -> TEST_VALUE)).isEqualTo(TEST_VALUE);
             assertThat(cache.get(TEST_KEY)).isNotNull();
             assertThat(cache.values()).hasSize(1);
             assertThat(cache.values()).containsOnly(TEST_VALUE);
+        }
+
+        @Test
+        void should_remove_if_mapping_returns_null() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, "wrong_value");
+            assertThat(cache.compute(TEST_KEY, (k, v) -> null)).isNull();
+            assertThat(cache.get(TEST_KEY)).isNull();
+            assertThat(cache.values()).isEmpty();
         }
 
         @Test
@@ -393,8 +775,8 @@ class InMemoryCacheTest {
             CacheConfiguration configuration = CacheConfiguration.builder().build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
             cache.put(TEST_KEY, "wrong_value");
-            cache.compute(TEST_KEY, (k, v) -> TEST_VALUE);
-            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.compute(TEST_KEY, (k, v) -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
             assertThat(cache.values()).hasSize(1);
             assertThat(cache.values()).containsOnly(TEST_VALUE);
         }
@@ -403,8 +785,8 @@ class InMemoryCacheTest {
         void should_compute_to_cache_and_expired_after_ttl() {
             CacheConfiguration configuration = CacheConfiguration.builder().timeToLiveInMs(200).build();
             Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
-            cache.compute(TEST_KEY, (k, v) -> TEST_VALUE);
-            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.compute(TEST_KEY, (k, v) -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
             assertThat(cache.values()).hasSize(1);
             assertThat(cache.values()).containsOnly(TEST_VALUE);
 
@@ -429,7 +811,7 @@ class InMemoryCacheTest {
                     }
                 }
             );
-            cache.compute(TEST_KEY, (k, v) -> TEST_VALUE);
+            assertThat(cache.compute(TEST_KEY, (k, v) -> TEST_VALUE)).isEqualTo(TEST_VALUE);
             await()
                 .atMost(500, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
@@ -450,8 +832,103 @@ class InMemoryCacheTest {
                     }
                 }
             );
-            cache.compute(TEST_KEY, (k, v) -> TEST_VALUE);
-            cache.compute(TEST_KEY, (k, v) -> TEST_VALUE_UPDATED);
+            assertThat(cache.compute(TEST_KEY, (k, v) -> TEST_VALUE)).isEqualTo(TEST_VALUE);
+            assertThat(cache.compute(TEST_KEY, (k, v) -> TEST_VALUE_UPDATED)).isEqualTo(TEST_VALUE_UPDATED);
+            await()
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(listenerCalled).isTrue();
+                });
+        }
+    }
+
+    @Nested
+    class RxComputeTest {
+
+        @Test
+        void should_compute_if_no_key_present_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxCompute(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+        }
+
+        @Test
+        void should_remove_if_mapping_returns_null() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, "wrong_value");
+            assertThat(cache.rxCompute(TEST_KEY, (k, v) -> null).blockingGet()).isNull();
+            assertThat(cache.get(TEST_KEY)).isNull();
+            assertThat(cache.values()).isEmpty();
+        }
+
+        @Test
+        void should_compute_if_key_present_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            cache.put(TEST_KEY, "wrong_value");
+            assertThat(cache.rxCompute(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+        }
+
+        @Test
+        void should_compute_to_cache_and_expired_after_ttl() {
+            CacheConfiguration configuration = CacheConfiguration.builder().timeToLiveInMs(200).build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            assertThat(cache.rxCompute(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isEqualTo(TEST_VALUE);
+            assertThat(cache.values()).hasSize(1);
+            assertThat(cache.values()).containsOnly(TEST_VALUE);
+
+            await()
+                .atMost(400, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(cache.get(TEST_KEY)).isNull();
+                    assertThat(cache.values()).isEmpty();
+                });
+        }
+
+        @Test
+        void should_notify_listener_when_compute_value_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryAdded(final String key, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            assertThat(cache.rxCompute(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            await()
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(listenerCalled).isTrue();
+                });
+        }
+
+        @Test
+        void should_notify_listener_when_putting_updated_value_to_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryUpdated(final String key, final String oldValue, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            assertThat(cache.rxCompute(TEST_KEY, (k, v) -> TEST_VALUE).blockingGet()).isEqualTo(TEST_VALUE);
+            assertThat(cache.rxCompute(TEST_KEY, (k, v) -> TEST_VALUE_UPDATED).blockingGet()).isEqualTo(TEST_VALUE_UPDATED);
             await()
                 .atMost(500, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
@@ -496,6 +973,50 @@ class InMemoryCacheTest {
             );
             cache.put(TEST_KEY, TEST_VALUE);
             assertThat(cache.evict(TEST_KEY)).isNotNull();
+            await()
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertThat(listenerCalled).isTrue();
+                });
+        }
+    }
+
+    @Nested
+    class RxEvictTest {
+
+        @Test
+        void should_ignore_evicting_not_existing_entry_from_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+
+            assertThat(cache.rxEvict(TEST_KEY).blockingGet()).isNull();
+        }
+
+        @Test
+        void should_evict_existing_entry_from_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+
+            cache.put(TEST_KEY, TEST_VALUE);
+            assertThat(cache.get(TEST_KEY)).isNotNull();
+            assertThat(cache.rxEvict(TEST_KEY).blockingGet()).isEqualTo(TEST_VALUE);
+        }
+
+        @Test
+        void should_notify_listener_when_evicting_value_from_cache() {
+            CacheConfiguration configuration = CacheConfiguration.builder().build();
+            Cache<String, String> cache = new InMemoryCache<>(CACHE_NAME, configuration);
+            AtomicBoolean listenerCalled = new AtomicBoolean();
+            cache.addCacheListener(
+                new CacheListener<>() {
+                    @Override
+                    public void onEntryEvicted(final String key, final String value) {
+                        listenerCalled.set(true);
+                    }
+                }
+            );
+            cache.put(TEST_KEY, TEST_VALUE);
+            assertThat(cache.rxEvict(TEST_KEY).blockingGet()).isEqualTo(TEST_VALUE);
             await()
                 .atMost(500, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {

--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
@@ -97,8 +97,8 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public Single<V> rxPut(final K key, final V value) {
-        return Single.fromCompletionStage(this.cache.putAsync(key, value));
+    public Maybe<V> rxPut(final K key, final V value) {
+        return Maybe.fromCompletionStage(this.cache.putAsync(key, value));
     }
 
     @Override
@@ -121,8 +121,8 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V computeIfAbsent(final K key, final Function<? super K, ? extends V> mappingFunction) {
-        return this.cache.computeIfAbsent(key, mappingFunction);
+    public V computeIfAbsent(final K key, final Function<? super K, ? extends V> remappingFunction) {
+        return this.cache.computeIfAbsent(key, remappingFunction);
     }
 
     @Override


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-392

**Description**

This PR fixes possible `NullPointerException` when using reactive `rxPut` and `rxCompute` methods which may return null value that is not allowed with `Single`. 

BREAKING CHANGE: Method signatures have changed from `Single` to `Maybe`. An empty Maybe means 'null' in the blocking world.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-archi-392-fix-rx-methods-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.0.0-archi-392-fix-rx-methods-SNAPSHOT/gravitee-node-6.0.0-archi-392-fix-rx-methods-SNAPSHOT.zip)
  <!-- Version placeholder end -->
