### PR TITLE
refactor: add default implementation for MemberListener

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/MemberListener.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/MemberListener.java
@@ -20,7 +20,7 @@ package io.gravitee.node.api.cluster;
  * @author GraviteeSource Team
  */
 public interface MemberListener {
-    void onMemberAdded(final Member member);
+    default void onMemberAdded(final Member member) {}
 
-    void onMemberRemoved(final Member member);
+    default void onMemberRemoved(final Member member) {}
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-391
**Description**

Add default key work on MemberListener interface to avoid being forced to implement empty method.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.0.0/gravitee-node-6.0.0.zip)
  <!-- Version placeholder end -->
