### PR TITLE
fix: ensure default hazelcast instance names are different

### DIFF
--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/spring/HazelcastCacheConfiguration.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/spring/HazelcastCacheConfiguration.java
@@ -39,7 +39,7 @@ public class HazelcastCacheConfiguration {
     @Value("${cache.hazelcast.config-path:${gravitee.home}/config/hazelcast-cache.xml}")
     private String hazelcastConfigFilePath;
 
-    @Value("${cache.hazelcast.instance-name:gio-hz-instance}")
+    @Value("${cache.hazelcast.instance-name:gio-cache-hz-instance}")
     private String hazelcastInstanceName;
 
     @Autowired

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/spring/HazelcastClusterConfiguration.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/spring/HazelcastClusterConfiguration.java
@@ -39,7 +39,7 @@ public class HazelcastClusterConfiguration {
     @Value("${cluster.hazelcast.config-path:${gravitee.home}/config/hazelcast-cluster.xml}")
     private String hazelcastConfigFilePath;
 
-    @Value("${cluster.hazelcast.instance-name:gio-hz-instance}")
+    @Value("${cluster.hazelcast.instance-name:gio-cluster-hz-instance}")
     private String hazelcastInstanceName;
 
     @Autowired


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-391

**Description**

For some reason, the fact both instances have the same name could cause an issue even if both hazelcast instances are isolated... 🤷‍♂️

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

