### PR TITLE
Archi 391 fix evict implementation

### DIFF
--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCache.java
@@ -136,11 +136,13 @@ public class HazelcastCache<K, V> implements Cache<K, V> {
     }
 
     @Override
-    public V evict(K key) {
-        V v = cache.get(key);
-        cache.remove(key);
+    public Maybe<V> rxEvict(final K key) {
+        return Maybe.fromCompletionStage(this.cache.removeAsync(key));
+    }
 
-        return v;
+    @Override
+    public V evict(K key) {
+        return cache.remove(key);
     }
 
     @Override

--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCacheManager.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cache/hazelcast/HazelcastCacheManager.java
@@ -90,11 +90,10 @@ public class HazelcastCacheManager extends AbstractService<CacheManager> impleme
 
             if (configuration.getMaxSize() > 0) {
                 mapConfig.getEvictionConfig().setSize((int) configuration.getMaxSize());
-            }
-
-            if (mapConfig.getEvictionConfig().getEvictionPolicy().equals(EvictionPolicy.NONE)) {
-                // Set "Least Recently Used" eviction policy if not have eviction configured
-                mapConfig.getEvictionConfig().setEvictionPolicy(EvictionPolicy.LRU);
+                if (mapConfig.getEvictionConfig().getEvictionPolicy().equals(EvictionPolicy.NONE)) {
+                    // Set "Least Recently Used" eviction policy if not have eviction configured
+                    mapConfig.getEvictionConfig().setEvictionPolicy(EvictionPolicy.LRU);
+                }
             }
 
             if (configuration.getTimeToIdleInMs() > 0) {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-391

**Description**

A synchronization issue has been detected using hazelcast cache especialy when evicting (removing) an element.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.4-archi-391-fix-evict-implementation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.0.4-archi-391-fix-evict-implementation-SNAPSHOT/gravitee-node-6.0.4-archi-391-fix-evict-implementation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
