### PR TITLE
feat: addition of Redis as cache implementation

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/CacheException.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/CacheException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.node.api.cache;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CacheException extends RuntimeException {
+
+    public CacheException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CacheException(String message) {
+        super(message);
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/CacheManager.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/CacheManager.java
@@ -24,13 +24,13 @@ import io.gravitee.common.service.Service;
 public interface CacheManager extends Service<CacheManager> {
     <K, V> Cache<K, V> getOrCreateCache(String name);
 
-    default <K, V, MV> Cache<K, V> getOrCreateCache(String name, ValueMapper<V, MV> valueMapper) {
+    default <K, V, C> Cache<K, V> getOrCreateCache(String name, ValueMapper<V, C> valueMapper) {
         return getOrCreateCache(name);
     }
 
     <K, V> Cache<K, V> getOrCreateCache(String name, CacheConfiguration configuration);
 
-    default <K, V, MV> Cache<K, V> getOrCreateCache(String name, CacheConfiguration configuration, ValueMapper<V, MV> valueMapper) {
+    default <K, V, C> Cache<K, V> getOrCreateCache(String name, CacheConfiguration configuration, ValueMapper<V, C> valueMapper) {
         return getOrCreateCache(name, configuration);
     }
 

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/CacheManager.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/CacheManager.java
@@ -24,7 +24,15 @@ import io.gravitee.common.service.Service;
 public interface CacheManager extends Service<CacheManager> {
     <K, V> Cache<K, V> getOrCreateCache(String name);
 
+    default <K, V, MV> Cache<K, V> getOrCreateCache(String name, ValueMapper<V, MV> valueMapper) {
+        return getOrCreateCache(name);
+    }
+
     <K, V> Cache<K, V> getOrCreateCache(String name, CacheConfiguration configuration);
+
+    default <K, V, MV> Cache<K, V> getOrCreateCache(String name, CacheConfiguration configuration, ValueMapper<V, MV> valueMapper) {
+        return getOrCreateCache(name, configuration);
+    }
 
     void destroy(String name);
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/ValueMapper.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/ValueMapper.java
@@ -23,10 +23,10 @@ package io.gravitee.node.api.cache;
  * expected by the application.
  *
  * @param <V> the value type provided by the application
- * @param <MV> the value type accepted by the caching system
+ * @param <C> the value type accepted by the caching system
  */
-public interface ValueMapper<V, MV> {
-    MV toCachedValue(V value);
+public interface ValueMapper<V, C> {
+    C toCachedValue(V value);
 
-    V toValue(MV cachedValue);
+    V toValue(C cachedValue);
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/ValueMapper.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cache/ValueMapper.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.node.api.cache;
+
+/**
+ * Some caching system only accept String or primitive values so java object can't be stored.
+ * This interface allows to provide to the cache implementation a mapper to convert the value provided to the
+ * cache object in a type accepted by the caching system and in the same way convert the cached value to a type
+ * expected by the application.
+ *
+ * @param <V> the value type provided by the application
+ * @param <MV> the value type accepted by the caching system
+ */
+public interface ValueMapper<V, MV> {
+    MV toCachedValue(V value);
+
+    V toValue(MV cachedValue);
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.node</groupId>
+        <artifactId>gravitee-node-cache</artifactId>
+        <version>6.0.4</version>
+    </parent>
+
+    <artifactId>gravitee-node-cache-plugin-redis</artifactId>
+    <name>Gravitee.io - Node - Cache - Plugin - Redis</name>
+    <description>Redis Cache allows to use caches based on Redis instance.</description>
+
+    <properties>
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>plugins/node-cache</publish-folder-path>
+        <commons-pool2.version>2.12.0</commons-pool2.version>
+        <embedded-redis.version>1.4.3</embedded-redis.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-vertx</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-redis-client</artifactId>
+        </dependency>
+
+        <!-- Embedded redis dependencies for unit test -->
+        <dependency>
+            <groupId>com.github.codemonstur</groupId>
+            <artifactId>embedded-redis</artifactId>
+            <version>${embedded-redis.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>${commons-pool2.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Include plugin schema configuration -->
+	<fileSets>
+		<fileSet>
+			<directory>src/main/resources/schemas</directory>
+			<outputDirectory>schemas</outputDirectory>
+		</fileSet>
+	</fileSets>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/RedisCache.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/RedisCache.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugin.cache.redis;
+
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.node.api.cache.CacheConfiguration;
+import io.gravitee.node.api.cache.CacheException;
+import io.gravitee.node.api.cache.CacheListener;
+import io.gravitee.node.api.cache.ValueMapper;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Response;
+import io.vertx.redis.client.ResponseType;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class RedisCache<V> implements Cache<String, V> {
+
+    public static final String SEPARATOR = ".";
+    private final String name;
+    private final CacheConfiguration cacheConfiguration;
+    private final ValueMapper<V, String> valueMapper;
+    private final RedisAPI redisAPI;
+    private final Map<String, CacheListener<String, V>> cacheListeners = new HashMap<>();
+
+    public RedisCache(String name, CacheConfiguration cacheConfiguration, RedisAPI redisAPI, ValueMapper<V, String> mapper) {
+        this.name = name;
+        this.cacheConfiguration = cacheConfiguration;
+        this.redisAPI = redisAPI;
+        if (mapper == null) {
+            throw new IllegalArgumentException("ValueMapper required for Redis Cache");
+        }
+        this.valueMapper = mapper;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    private String getRedisEntryKey(String key) {
+        return this.name + SEPARATOR + key;
+    }
+
+    private Single<Response> throwExceptionOnError(Response response) {
+        if (ResponseType.ERROR == response.type()) {
+            Single.error(new CacheException("Error during cache operation: " + response.format()));
+        }
+        return Single.just(response);
+    }
+
+    @Override
+    public Collection<V> values() {
+        throw new UnsupportedOperationException("Redis cache does not support values operation");
+    }
+
+    @Override
+    public Flowable<String> rxKeys() {
+        return Single
+            .fromCompletionStage(this.redisAPI.keys(getRedisEntryKey("*")).toCompletionStage())
+            .flatMap(this::throwExceptionOnError)
+            .flattenStreamAsFlowable(Response::stream)
+            .map(response -> response.toString(StandardCharsets.UTF_8).replace(getRedisEntryKey(""), ""));
+    }
+
+    @Override
+    public Set<String> keys() {
+        return this.rxKeys().collectInto(new HashSet<String>(), HashSet::add).blockingGet();
+    }
+
+    @Override
+    public Set<Map.Entry<String, V>> entrySet() {
+        throw new UnsupportedOperationException("Redis cache does not support entrySet operation");
+    }
+
+    @Override
+    public int size() {
+        throw new UnsupportedOperationException("Redis cache does not support size operation");
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.rxIsEmpty().blockingGet();
+    }
+
+    @Override
+    public Single<Boolean> rxIsEmpty() {
+        return this.rxKeys().isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return this.rxContainsKey(key).blockingGet();
+    }
+
+    @Override
+    public Single<Boolean> rxContainsKey(String key) {
+        return Single
+            .fromCompletionStage(this.redisAPI.exists(List.of(key + SEPARATOR)).toCompletionStage())
+            .flatMap(this::throwExceptionOnError)
+            .map(resp -> resp.toInteger() > 0);
+    }
+
+    @Override
+    public V get(String key) {
+        return this.rxGet(key).blockingGet();
+    }
+
+    @Override
+    public Maybe<V> rxGet(String key) {
+        return Maybe
+            .fromCompletionStage(this.redisAPI.get(getRedisEntryKey(key)).toCompletionStage())
+            .flatMapSingle(this::throwExceptionOnError)
+            .map(response -> valueMapper.toValue(asString(response)));
+    }
+
+    @Override
+    public V put(String key, V value) {
+        return this.rxPut(key, value).blockingGet();
+    }
+
+    @Override
+    public Maybe<V> rxPut(String key, V value) {
+        return rxGet(key)
+            .map(Optional::ofNullable)
+            .switchIfEmpty(Maybe.just(Optional.empty()))
+            .flatMap(oldValue ->
+                Maybe
+                    .fromCompletionStage(this.redisAPI.setnx(getRedisEntryKey(key), valueMapper.toCachedValue(value)).toCompletionStage())
+                    .map(this::throwExceptionOnError)
+                    .mapOptional(r -> {
+                        this.cacheListeners.values()
+                            .forEach(listener ->
+                                oldValue.ifPresentOrElse(
+                                    old -> listener.onEntryUpdated(key, old, value),
+                                    () -> listener.onEntryAdded(key, value)
+                                )
+                            );
+                        return oldValue;
+                    })
+            );
+    }
+
+    @Override
+    public V put(String key, V value, long ttl, TimeUnit ttlUnit) {
+        return this.rxPut(key, value, ttl, ttlUnit).blockingGet();
+    }
+
+    @Override
+    public Maybe<V> rxPut(String key, V value, long ttl, TimeUnit ttlUnit) {
+        return rxGet(key)
+            .map(Optional::ofNullable)
+            .switchIfEmpty(Maybe.just(Optional.empty()))
+            .flatMap(oldValue ->
+                Maybe
+                    .fromCompletionStage(
+                        this.redisAPI.set(
+                                List.of(getRedisEntryKey(key), valueMapper.toCachedValue(value), "PX", "" + ttlUnit.toMillis(ttl))
+                            )
+                            .toCompletionStage()
+                    )
+                    .map(this::throwExceptionOnError)
+                    .mapOptional(r -> {
+                        this.cacheListeners.values()
+                            .forEach(listener ->
+                                oldValue.ifPresentOrElse(
+                                    old -> listener.onEntryUpdated(key, old, value),
+                                    () -> listener.onEntryAdded(key, value)
+                                )
+                            );
+                        return oldValue;
+                    })
+            );
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends V> m) {
+        this.rxPutAll(m).blockingAwait();
+    }
+
+    @Override
+    public Completable rxPutAll(Map<? extends String, ? extends V> m) {
+        return Flowable
+            .fromIterable(m.entrySet())
+            .flatMapCompletable(entry -> this.rxPut(entry.getKey(), entry.getValue()).ignoreElement());
+    }
+
+    @Override
+    public V computeIfAbsent(String key, Function<? super String, ? extends V> remappingFunction) {
+        return this.rxComputeIfAbsent(key, remappingFunction).blockingGet();
+    }
+
+    @Override
+    public Maybe<V> rxComputeIfAbsent(String key, Function<? super String, ? extends V> mappingFunction) {
+        throw new UnsupportedOperationException("Redis cache does not support computeIfAbsent operation");
+    }
+
+    @Override
+    public V computeIfPresent(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+        return this.rxComputeIfPresent(key, remappingFunction).blockingGet();
+    }
+
+    @Override
+    public Maybe<V> rxComputeIfPresent(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+        throw new UnsupportedOperationException("Redis cache does not support computeIfPresent operation");
+    }
+
+    @Override
+    public V compute(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+        return this.rxCompute(key, remappingFunction).blockingGet();
+    }
+
+    @Override
+    public Maybe<V> rxCompute(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+        throw new UnsupportedOperationException("Redis cache does not support compute operation");
+    }
+
+    @Override
+    public V evict(String key) {
+        return this.rxEvict(key).blockingGet();
+    }
+
+    @Override
+    public Maybe<V> rxEvict(String key) {
+        return this.rxGet(key)
+            .flatMap(value ->
+                Maybe
+                    .fromCompletionStage(this.redisAPI.del(List.of(getRedisEntryKey(key))).toCompletionStage())
+                    .map(this::throwExceptionOnError)
+                    .map(ignore -> {
+                        this.cacheListeners.values().forEach(listener -> listener.onEntryEvicted(key, value));
+                        return value;
+                    })
+            );
+    }
+
+    @Override
+    public void clear() {
+        this.rxClear().blockingAwait();
+    }
+
+    @Override
+    public Completable rxClear() {
+        return this.rxKeys().flatMapCompletable(key -> rxEvict(key).ignoreElement());
+    }
+
+    @Override
+    public String addCacheListener(CacheListener<String, V> listener) {
+        String listenerCacheId = io.gravitee.common.utils.UUID.random().toString();
+        cacheListeners.put(listenerCacheId, listener);
+
+        return listenerCacheId;
+    }
+
+    @Override
+    public boolean removeCacheListener(String listenerCacheId) {
+        return cacheListeners.remove(listenerCacheId) != null;
+    }
+
+    private static String asString(Response response) {
+        return response.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/RedisCache.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/RedisCache.java
@@ -16,7 +16,6 @@
 package io.gravitee.node.plugin.cache.redis;
 
 import io.gravitee.node.api.cache.Cache;
-import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.api.cache.CacheException;
 import io.gravitee.node.api.cache.CacheListener;
 import io.gravitee.node.api.cache.ValueMapper;
@@ -28,13 +27,7 @@ import io.vertx.redis.client.RedisAPI;
 import io.vertx.redis.client.Response;
 import io.vertx.redis.client.ResponseType;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -49,14 +42,12 @@ public class RedisCache<V> implements Cache<String, V> {
 
     public static final String SEPARATOR = ".";
     private final String name;
-    private final CacheConfiguration cacheConfiguration;
     private final ValueMapper<V, String> valueMapper;
     private final RedisAPI redisAPI;
     private final Map<String, CacheListener<String, V>> cacheListeners = new HashMap<>();
 
-    public RedisCache(String name, CacheConfiguration cacheConfiguration, RedisAPI redisAPI, ValueMapper<V, String> mapper) {
+    public RedisCache(String name, RedisAPI redisAPI, ValueMapper<V, String> mapper) {
         this.name = name;
-        this.cacheConfiguration = cacheConfiguration;
         this.redisAPI = redisAPI;
         if (mapper == null) {
             throw new IllegalArgumentException("ValueMapper required for Redis Cache");
@@ -75,7 +66,7 @@ public class RedisCache<V> implements Cache<String, V> {
 
     private Single<Response> throwExceptionOnError(Response response) {
         if (ResponseType.ERROR == response.type()) {
-            Single.error(new CacheException("Error during cache operation: " + response.format()));
+            return Single.error(new CacheException("Error during cache operation: " + response.format()));
         }
         return Single.just(response);
     }

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/RedisCacheManager.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/RedisCacheManager.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugin.cache.redis;
+
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.node.api.cache.CacheConfiguration;
+import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.node.api.cache.ValueMapper;
+import io.gravitee.node.plugin.cache.redis.configuration.RedisConfiguration;
+import io.gravitee.node.plugin.cache.redis.configuration.RedisOptionsFactory;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisAPI;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import lombok.AccessLevel;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RedisCacheManager extends AbstractService<CacheManager> implements CacheManager {
+
+    private final ConcurrentMap<String, Cache<?, ?>> caches = new ConcurrentHashMap<>();
+
+    @Autowired
+    @Setter(AccessLevel.PACKAGE)
+    private RedisConfiguration redisConfiguration;
+
+    @Autowired
+    @Setter(AccessLevel.PACKAGE)
+    private Vertx vertx;
+
+    private RedisAPI redisAPI;
+
+    @Override
+    public <K, V> Cache<K, V> getOrCreateCache(final String name) {
+        return getOrCreateCache(name, new CacheConfiguration(), null);
+    }
+
+    @Override
+    public <K, V, MV> Cache<K, V> getOrCreateCache(String name, ValueMapper<V, MV> valueMapper) {
+        return getOrCreateCache(name, new CacheConfiguration(), valueMapper);
+    }
+
+    @Override
+    public <K, V> Cache<K, V> getOrCreateCache(String name, CacheConfiguration configuration) {
+        return getOrCreateCache(name, configuration, null);
+    }
+
+    @Override
+    public <K, V, MV> Cache<K, V> getOrCreateCache(String name, CacheConfiguration configuration, ValueMapper<V, MV> valueMapper) {
+        return (Cache<K, V>) caches.computeIfAbsent(
+            name,
+            s -> new RedisCache<V>(name, configuration, getOrCreateRedisAPI(), (ValueMapper<V, String>) valueMapper)
+        );
+    }
+
+    @Override
+    public void destroy(final String cacheName) {
+        Cache<?, ?> cache = caches.remove(cacheName);
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        if (redisAPI != null) {
+            redisAPI.close();
+        }
+    }
+
+    private synchronized RedisAPI getOrCreateRedisAPI() {
+        if (redisAPI == null) {
+            this.redisAPI = RedisAPI.api(Redis.createClient(vertx, RedisOptionsFactory.build(redisConfiguration)));
+        }
+        return this.redisAPI;
+    }
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/HostAndPort.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/HostAndPort.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugin.cache.redis.configuration;
+
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Getter
+public class HostAndPort {
+
+    private final String host;
+    private final int port;
+    private String password;
+    private boolean useSsl;
+
+    private HostAndPort(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public static HostAndPort of(String host, int port) {
+        return new HostAndPort(host, port);
+    }
+
+    public HostAndPort withPassword(String password) {
+        this.password = password;
+
+        return this;
+    }
+
+    public HostAndPort withSsl(boolean useSsl) {
+        this.useSsl = useSsl;
+
+        return this;
+    }
+
+    public String toConnectionString() {
+        String connectionType = "redis";
+
+        if (useSsl) {
+            connectionType = "rediss";
+        }
+
+        if (StringUtils.hasText(password)) {
+            return connectionType + "://:" + password + '@' + host + ':' + port;
+        }
+
+        return connectionType + "://" + host + ':' + port;
+    }
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/HostAndPort.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/HostAndPort.java
@@ -15,40 +15,24 @@
  */
 package io.gravitee.node.plugin.cache.redis.configuration;
 
-import lombok.Getter;
 import org.springframework.util.StringUtils;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Getter
-public class HostAndPort {
 
-    private final String host;
-    private final int port;
-    private String password;
-    private boolean useSsl;
-
-    private HostAndPort(String host, int port) {
-        this.host = host;
-        this.port = port;
-    }
-
+public record HostAndPort(String host, int port, String password, boolean useSsl) {
     public static HostAndPort of(String host, int port) {
-        return new HostAndPort(host, port);
+        return new HostAndPort(host, port, null, false);
     }
 
     public HostAndPort withPassword(String password) {
-        this.password = password;
-
-        return this;
+        return new HostAndPort(host, port, password, false);
     }
 
     public HostAndPort withSsl(boolean useSsl) {
-        this.useSsl = useSsl;
-
-        return this;
+        return new HostAndPort(host, port, password, useSsl);
     }
 
     public String toConnectionString() {

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisConfiguration.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugin.cache.redis.configuration;
+
+import io.gravitee.node.vertx.client.ssl.SslOptions;
+import lombok.Data;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Data
+public class RedisConfiguration {
+
+    private HostAndPort hostAndPort;
+    private SentinelConfiguration sentinelConfiguration;
+    private SslOptions sslConfiguration;
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisConfigurationProvider.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisConfigurationProvider.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.node.plugin.cache.redis.configuration;
+
+import io.gravitee.node.vertx.client.ssl.KeyStore;
+import io.gravitee.node.vertx.client.ssl.KeyStoreType;
+import io.gravitee.node.vertx.client.ssl.SslOptions;
+import io.gravitee.node.vertx.client.ssl.TrustStore;
+import io.gravitee.node.vertx.client.ssl.jks.JKSKeyStore;
+import io.gravitee.node.vertx.client.ssl.jks.JKSTrustStore;
+import io.gravitee.node.vertx.client.ssl.none.NoneKeyStore;
+import io.gravitee.node.vertx.client.ssl.none.NoneTrustStore;
+import io.gravitee.node.vertx.client.ssl.pem.PEMKeyStore;
+import io.gravitee.node.vertx.client.ssl.pem.PEMTrustStore;
+import io.gravitee.node.vertx.client.ssl.pkcs12.PKCS12KeyStore;
+import io.gravitee.node.vertx.client.ssl.pkcs12.PKCS12TrustStore;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class RedisConfigurationProvider {
+
+    public static final String SENTINEL_PREFIX = ".sentinel";
+
+    public static RedisConfiguration from(Environment environment, String propertiesPrefix) {
+        RedisConfiguration config = new RedisConfiguration();
+
+        final var host = environment.getProperty(propertiesPrefix + ".host", String.class, "localhost");
+        final var port = environment.getProperty(propertiesPrefix + ".port", Integer.class, 6379);
+        final var password = environment.getProperty(propertiesPrefix + ".password", String.class);
+        final var useSsl = environment.getProperty(propertiesPrefix + ".ssl", Boolean.class, false);
+
+        final var hostAndPort = HostAndPort.of(host, port).withPassword(password).withSsl(useSsl);
+        config.setHostAndPort(hostAndPort);
+
+        SentinelConfiguration sentinelConfiguration = new SentinelConfiguration();
+        sentinelConfiguration.setEnabled(isSentinelEnabled(environment, propertiesPrefix));
+        if (sentinelConfiguration.isEnabled()) {
+            sentinelConfiguration.setMaster(
+                environment.getProperty(propertiesPrefix + SENTINEL_PREFIX + ".master", String.class, "mymaster")
+            );
+            sentinelConfiguration.setMaster(environment.getProperty(propertiesPrefix + SENTINEL_PREFIX + ".password", String.class));
+
+            List<HostAndPort> sentinelNodes = getSentinelNodes(environment, propertiesPrefix);
+            sentinelNodes.forEach(node -> node.withPassword(hostAndPort.getPassword()).withSsl(hostAndPort.isUseSsl()));
+            sentinelConfiguration.setNodes(sentinelNodes);
+        }
+        config.setSentinelConfiguration(sentinelConfiguration);
+
+        if (useSsl) {
+            final var useOpenSSL = environment.getProperty(propertiesPrefix + ".openssl", Boolean.class, false);
+            final var trustAll = environment.getProperty(propertiesPrefix + ".trustAll", Boolean.class, false);
+            final var hostnameVerificationAlgorithm = environment.getProperty(
+                propertiesPrefix + ".hostnameVerificationAlgorithm",
+                String.class,
+                "NONE"
+            );
+
+            final var sslConfig = new SslOptions();
+            sslConfig.setTrustAll(trustAll);
+            sslConfig.setOpenSsl(useOpenSSL);
+            sslConfig.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+            sslConfig.setKeyStore(loadKeyStore(environment, propertiesPrefix + ".keystore"));
+            sslConfig.setTrustStore(loadTrustStore(environment, propertiesPrefix + ".truststore"));
+            config.setSslConfiguration(sslConfig);
+        }
+
+        return config;
+    }
+
+    private static KeyStore loadKeyStore(Environment environment, String propertiesPrefix) {
+        String path = environment.getProperty(propertiesPrefix + ".path", String.class);
+        String type = environment.getProperty(propertiesPrefix + ".type", String.class);
+        String password = environment.getProperty(propertiesPrefix + ".password", String.class);
+        String keyPassword = environment.getProperty(propertiesPrefix + ".keyPassword", String.class);
+        String alias = environment.getProperty(propertiesPrefix + ".alias", String.class);
+        String keyPath = environment.getProperty(propertiesPrefix + ".keyPath", String.class);
+
+        if (!StringUtils.hasText(path)) {
+            return new NoneKeyStore();
+        }
+
+        if (KeyStoreType.PKCS12.name().equalsIgnoreCase(type)) {
+            final var keystore = new PKCS12KeyStore();
+            keystore.setAlias(alias);
+            keystore.setPassword(password);
+            keystore.setKeyPassword(keyPassword);
+            keystore.setPath(path);
+            return keystore;
+        }
+
+        if (KeyStoreType.JKS.name().equalsIgnoreCase(type)) {
+            final var keystore = new JKSKeyStore();
+            keystore.setAlias(alias);
+            keystore.setPassword(password);
+            keystore.setKeyPassword(keyPassword);
+            keystore.setPath(path);
+            return keystore;
+        }
+
+        if (KeyStoreType.PEM.name().equalsIgnoreCase(type)) {
+            final var keystore = new PEMKeyStore();
+            keystore.setKeyPath(keyPath);
+            keystore.setCertPath(path);
+            return keystore;
+        }
+
+        return new NoneKeyStore();
+    }
+
+    private static TrustStore loadTrustStore(Environment environment, String propertiesPrefix) {
+        String path = environment.getProperty(propertiesPrefix + ".path", String.class);
+        String type = environment.getProperty(propertiesPrefix + ".type", String.class);
+        String password = environment.getProperty(propertiesPrefix + ".password", String.class);
+        String alias = environment.getProperty(propertiesPrefix + ".alias", String.class);
+
+        if (!StringUtils.hasText(path)) {
+            return new NoneTrustStore();
+        }
+
+        if (KeyStoreType.PKCS12.name().equalsIgnoreCase(type)) {
+            final var keystore = new PKCS12TrustStore();
+            keystore.setAlias(alias);
+            keystore.setPassword(password);
+            keystore.setPath(path);
+            return keystore;
+        }
+
+        if (KeyStoreType.JKS.name().equalsIgnoreCase(type)) {
+            final var keystore = new JKSTrustStore();
+            keystore.setAlias(alias);
+            keystore.setPassword(password);
+            keystore.setPath(path);
+            return keystore;
+        }
+
+        if (KeyStoreType.PEM.name().equalsIgnoreCase(type)) {
+            final var keystore = new PEMTrustStore();
+            keystore.setPath(path);
+            return keystore;
+        }
+
+        return new NoneTrustStore();
+    }
+
+    private static boolean isSentinelEnabled(Environment environment, String propertyPrefix) {
+        return StringUtils.hasLength(environment.getProperty(propertyPrefix + SENTINEL_PREFIX + ".nodes[0].host", String.class));
+    }
+
+    private static List<HostAndPort> getSentinelNodes(Environment environment, String propertyPrefix) {
+        final List<HostAndPort> nodes = new ArrayList<>();
+        for (
+            int idx = 0;
+            StringUtils.hasText(environment.getProperty(propertyPrefix + SENTINEL_PREFIX + ".nodes[" + idx + "].host", String.class));
+            idx++
+        ) {
+            String host = environment.getProperty(propertyPrefix + SENTINEL_PREFIX + ".nodes[" + idx + "].host", String.class);
+            int port = environment.getProperty(propertyPrefix + SENTINEL_PREFIX + ".nodes[" + idx + "].port", int.class);
+            nodes.add(HostAndPort.of(host, port));
+        }
+        return nodes;
+    }
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisOptionsFactory.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisOptionsFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugin.cache.redis.configuration;
+
+import io.gravitee.node.vertx.client.ssl.SslOptions;
+import io.gravitee.node.vertx.client.tcp.VertxTcpClientFactory;
+import io.vertx.redis.client.RedisClientType;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.redis.client.RedisRole;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class RedisOptionsFactory {
+
+    public static RedisOptions build(RedisConfiguration configuration) {
+        return buildRedisOptions(configuration);
+    }
+
+    private static RedisOptions buildRedisOptions(RedisConfiguration configuration) {
+        final RedisOptions options = new RedisOptions();
+
+        final var sentinelConfiguration = configuration.getSentinelConfiguration();
+        if (sentinelConfiguration != null && sentinelConfiguration.isEnabled()) {
+            // Sentinels + Redis master / replicas
+            log.debug("Redis repository configured to use Sentinel connection");
+
+            options.setType(RedisClientType.SENTINEL);
+            List<HostAndPort> sentinelNodes = sentinelConfiguration.getNodes();
+            sentinelNodes.forEach(hostAndPort -> options.addConnectionString(hostAndPort.toConnectionString()));
+
+            if (!StringUtils.hasText(sentinelConfiguration.getMaster())) {
+                throw new IllegalStateException("Incorrect Sentinel configuration : parameter 'master' is mandatory!");
+            }
+            options.setMasterName(sentinelConfiguration.getMaster()).setRole(RedisRole.MASTER);
+            options.setPassword(sentinelConfiguration.getPassword());
+        } else {
+            // Standalone Redis
+            log.debug("Redis repository configured to use standalone connection");
+
+            options.setType(RedisClientType.STANDALONE);
+            options.setConnectionString(configuration.getHostAndPort().toConnectionString());
+        }
+
+        if (configuration.getHostAndPort().isUseSsl()) {
+            log.debug("Redis repository configured with ssl enabled");
+            SslOptions sslConfiguration = configuration.getSslConfiguration();
+            options.getNetClientOptions().setSsl(true);
+            VertxTcpClientFactory.configureSslClientOption(options.getNetClientOptions(), sslConfiguration);
+        }
+
+        // Set max waiting handlers high enough to manage high throughput since we are not using the pooled mode
+        options.setMaxWaitingHandlers(1024);
+        return options;
+    }
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisOptionsFactory.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisOptionsFactory.java
@@ -31,6 +31,10 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class RedisOptionsFactory {
 
+    private RedisOptionsFactory() {
+        // no op
+    }
+
     public static RedisOptions build(RedisConfiguration configuration) {
         return buildRedisOptions(configuration);
     }
@@ -60,7 +64,7 @@ public class RedisOptionsFactory {
             options.setConnectionString(configuration.getHostAndPort().toConnectionString());
         }
 
-        if (configuration.getHostAndPort().isUseSsl()) {
+        if (configuration.getHostAndPort().useSsl()) {
             log.debug("Redis repository configured with ssl enabled");
             SslOptions sslConfiguration = configuration.getSslConfiguration();
             options.getNetClientOptions().setSsl(true);

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/SentinelConfiguration.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/SentinelConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.plugin.cache.redis.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Data
+public class SentinelConfiguration {
+
+    private boolean enabled;
+    private String master;
+    private String password;
+    private List<HostAndPort> nodes = new ArrayList<>();
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/spring/RedisCacheConfiguration.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/spring/RedisCacheConfiguration.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.node.plugin.cache.redis.spring;
+
+import io.gravitee.node.plugin.cache.redis.configuration.RedisConfiguration;
+import io.gravitee.node.plugin.cache.redis.configuration.RedisConfigurationProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class RedisCacheConfiguration {
+
+    @Bean
+    public RedisConfiguration getRedisAPI(Environment environment) {
+        return RedisConfigurationProvider.from(environment, "cache.redis");
+    }
+}

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/resources/plugin.properties
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/resources/plugin.properties
@@ -1,0 +1,6 @@
+id=cache-redis
+name=Redis Cache
+version=${project.version}
+description=${project.description}
+class=io.gravitee.node.plugin.cache.redis.RedisCacheManager
+type=cache

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/test/java/io/gravitee/node/plugin/cache/redis/RedisCacheTest.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/test/java/io/gravitee/node/plugin/cache/redis/RedisCacheTest.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.node.plugin.cache.redis;
+
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.node.api.cache.CacheConfiguration;
+import io.gravitee.node.api.cache.ValueMapper;
+import io.gravitee.node.plugin.cache.redis.configuration.HostAndPort;
+import io.gravitee.node.plugin.cache.redis.configuration.RedisConfiguration;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.Vertx;
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import redis.embedded.RedisServer;
+
+/**
+ * @author Eric LELEU (eric.leleu at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class RedisCacheTest {
+
+    private static RedisServer redisServer;
+    private static Cache<String, String> redisCache;
+
+    @BeforeAll
+    public static void redisInitialization() throws IOException {
+        redisServer = new RedisServer(6379);
+        redisServer.start();
+
+        final var redisConfiguration = new RedisConfiguration();
+        redisConfiguration.setHostAndPort(HostAndPort.of("localhost", 6379));
+
+        final var cm = new RedisCacheManager();
+        cm.setVertx(Vertx.vertx());
+        cm.setRedisConfiguration(redisConfiguration);
+        redisCache =
+            cm.getOrCreateCache(
+                "test",
+                CacheConfiguration.builder().build(),
+                new ValueMapper<String, String>() {
+                    @Override
+                    public String toCachedValue(String value) {
+                        return value;
+                    }
+
+                    @Override
+                    public String toValue(String cachedValue) {
+                        return cachedValue;
+                    }
+                }
+            );
+    }
+
+    @Test
+    public void should_store_a_key() throws Exception {
+        final var key = UUID.randomUUID().toString();
+        TestObserver<String> test = redisCache.rxPut(key, "myvalue1").test();
+        test.await();
+        test.assertNoValues(); // when key is missing the put return nothing
+
+        test = redisCache.rxGet(key).test();
+        test.await();
+        test.assertValue("myvalue1");
+
+        test = redisCache.rxPut(key, "myvalue2").test();
+        test.await();
+        test.assertValue("myvalue1"); // when key is present the put return previous value
+    }
+
+    @Test
+    public void should_store_a_key_with_ttl() throws Exception {
+        final var key = UUID.randomUUID().toString();
+        TestObserver<String> test = redisCache.rxPut(key, "myvalue1", 5, TimeUnit.SECONDS).test();
+        test.await();
+        test.assertNoValues(); // when key is missing the put return nothing
+
+        test = redisCache.rxGet(key).test();
+        test.await();
+        test.assertValue("myvalue1");
+
+        Thread.sleep(6000);
+
+        test = redisCache.rxGet(key).test();
+        test.await();
+        test.assertNoValues();
+    }
+
+    @Test
+    public void should_store_all_map_entries() throws Exception {
+        final var entries = Map.of("key1", UUID.randomUUID().toString(), "key2", UUID.randomUUID().toString());
+
+        var testGet = redisCache.rxGet("key1").test();
+        testGet.await();
+        testGet.assertNoValues();
+
+        var testPutAll = redisCache.rxPutAll(entries).test();
+        testPutAll.await();
+        testPutAll.assertNoErrors();
+
+        testGet = redisCache.rxGet("key1").test();
+        testGet.await();
+        testGet.assertValue(entries.get("key1"));
+    }
+
+    @Test
+    public void should_evict_a_key() throws Exception {
+        final var key = UUID.randomUUID().toString();
+        TestObserver<String> test = redisCache.rxPut(key, "myvalue1").test();
+        test.await();
+        test.assertNoValues(); // when key is missing the put return nothing
+
+        test = redisCache.rxGet(key).test();
+        test.await();
+        test.assertValue("myvalue1");
+
+        test = redisCache.rxEvict(key).test();
+        test.await();
+        test.assertValue("myvalue1"); // evict provide removed value
+
+        test = redisCache.rxGet(key).test();
+        test.await();
+        test.assertNoValues();
+    }
+
+    @Test
+    public void should_be_able_to_clear_cache() throws Exception {
+        // clear cache to remove all data from previous tests
+        var testClear = redisCache.rxClear().test();
+        testClear.await();
+        testClear.assertNoValues();
+        testClear.assertNoErrors();
+
+        // cache should be empty
+        var testEmpty = redisCache.rxIsEmpty().test();
+        testEmpty.await();
+        testEmpty.assertValue(true);
+
+        // insert entry
+        final var key = UUID.randomUUID().toString();
+        TestObserver<String> test = redisCache.rxPut(key, "myvalue1").test();
+        test.await();
+        test.assertNoValues(); // when key is missing the put return nothing
+
+        // Now test empty and clear operations
+        testEmpty = redisCache.rxIsEmpty().test();
+        testEmpty.await();
+        testEmpty.assertValue(false);
+
+        testClear = redisCache.rxClear().test();
+        testClear.await();
+        testClear.assertNoValues();
+        testClear.assertNoErrors();
+
+        testEmpty = redisCache.rxIsEmpty().test();
+        testEmpty.await();
+        testEmpty.assertValue(true);
+    }
+
+    @AfterAll
+    public static void shutdownRedisServer() {
+        if (redisServer != null) {
+            try {
+                redisServer.stop();
+            } catch (IOException e) {
+                log.warn("Unable to stop Redis Server: {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/gravitee-node-cache/pom.xml
+++ b/gravitee-node-cache/pom.xml
@@ -36,6 +36,7 @@
         <module>gravitee-node-cache-plugin-handler</module>
         <module>gravitee-node-cache-plugin-standalone</module>
         <module>gravitee-node-cache-plugin-hazelcast</module>
+        <module>gravitee-node-cache-plugin-redis</module>
     </modules>
     <dependencies>
         <dependency>

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
@@ -6,9 +6,7 @@ import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -25,6 +23,8 @@ public class SslOptions implements Serializable {
 
     private boolean trustAll;
     private boolean hostnameVerifier = true;
+
+    private boolean openSsl;
 
     @Builder.Default
     private String hostnameVerificationAlgorithm = "NONE";


### PR DESCRIPTION
this Implement doesn't covert all the methods.

A ValueMapper interface has been added to let the cache user define how to convert the value object as a String managed by Redis.

**NOTE:** For some reason the reactive client is not working inside the plugin and lead to a NoClassDefFoundException on the Redis client whereas the non reactive "RedisClient" is working.

related-to AM-3476
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.0-am-3476-redis-cache-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.1.0-am-3476-redis-cache-SNAPSHOT/gravitee-node-6.1.0-am-3476-redis-cache-SNAPSHOT.zip)
  <!-- Version placeholder end -->
