### PR TITLE
feat: allow merge of several gravitee.yml

### DIFF
--- a/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/env/PropertiesConfiguration.java
+++ b/gravitee-node-container/src/main/java/io/gravitee/node/container/spring/env/PropertiesConfiguration.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,14 +17,15 @@ package io.gravitee.node.container.spring.env;
 
 import io.gravitee.node.api.secrets.resolver.PropertyResolverFactoriesLoader;
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -43,12 +44,27 @@ public class PropertiesConfiguration {
 
         YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
 
-        String yamlConfiguration = System.getProperty(GRAVITEE_CONFIGURATION);
-        Resource yamlResource = new FileSystemResource(yamlConfiguration);
+        String yamlConfigurations = System.getProperty(GRAVITEE_CONFIGURATION);
+        if (yamlConfigurations == null) {
+            throw new IllegalArgumentException(GRAVITEE_CONFIGURATION + " must be set");
+        }
 
-        LOGGER.info("\tGravitee configuration loaded from {}", yamlResource.getURL().getPath());
+        List<FileSystemResource> yamlResources = Stream.of(yamlConfigurations.split(",")).map(FileSystemResource::new).toList();
 
-        yaml.setResources(yamlResource);
+        boolean first = true;
+        for (FileSystemResource yamlResource : yamlResources) {
+            final String action;
+            if (first) {
+                action = "loaded";
+                first = false;
+            } else {
+                action = "overridden";
+            }
+            LOGGER.info("\tGravitee configuration {} from {}", action, yamlResource.getURL().getPath());
+        }
+
+        yaml.setResources(yamlResources.toArray(new FileSystemResource[] {}));
+
         Properties properties = yaml.getObject();
         LOGGER.info("Loading Gravitee configuration. DONE");
 

--- a/gravitee-node-container/src/test/java/io/gravitee/node/container/spring/env/PropertiesConfigurationTest.java
+++ b/gravitee-node-container/src/test/java/io/gravitee/node/container/spring/env/PropertiesConfigurationTest.java
@@ -1,0 +1,50 @@
+package io.gravitee.node.container.spring.env;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class PropertiesConfigurationTest {
+
+    @Test
+    void should_load_gravitee_yaml() throws IOException {
+        PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+        System.setProperty(PropertiesConfiguration.GRAVITEE_CONFIGURATION, "src/test/resources/conf/gravitee.yml");
+        Properties properties = propertiesConfiguration.graviteeProperties();
+        assertThat(properties.getProperty("person.name")).isEqualTo("Hank");
+        assertThat(properties.getProperty("person.age")).isEqualTo("42");
+        assertThat(properties.getProperty("person.single")).isEqualTo("false");
+        assertThat(properties.getProperty("person.addresses[0].street")).isEqualTo("Venice Beach");
+        assertThat(properties.getProperty("person.addresses[0].town")).isEqualTo("Los Angeles");
+        assertThat(properties.getProperty("person.addresses[1].street")).isEqualTo("1st Avenue");
+        assertThat(properties.getProperty("person.addresses[1].town")).isEqualTo("Hollywood");
+        assertThat(properties.getProperty("person.emails[0]")).isEqualTo("hanky@gmail.com");
+        assertThat(properties.getProperty("creditCards[0]")).isEqualTo("visa");
+    }
+
+    @Test
+    void should_load_two_gravitee_yaml() throws IOException {
+        PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+        System.setProperty(
+            PropertiesConfiguration.GRAVITEE_CONFIGURATION,
+            "src/test/resources/conf/gravitee.yml,src/test/resources/conf/gravitee-override.yml"
+        );
+        Properties properties = propertiesConfiguration.graviteeProperties();
+        assertThat(properties.getProperty("person.name")).isEqualTo("Hank Moody");
+        assertThat(properties.getProperty("person.age")).isEqualTo("42");
+        assertThat(properties.getProperty("person.single")).isEqualTo("false");
+        assertThat(properties.getProperty("person.emails[0]")).isEqualTo("hanky@hotmail.com");
+        assertThat(properties.getProperty("person.addresses[0].street")).isEqualTo("Venice Beach");
+        assertThat(properties.getProperty("person.addresses[0].town")).isEqualTo("Los Angeles");
+        assertThat(properties.getProperty("person.addresses[1].street")).isEqualTo("1st Avenue");
+        assertThat(properties.getProperty("person.addresses[1].town")).isEqualTo("Hollywood, LA");
+        assertThat(properties.getProperty("person.addresses[2].street")).isEqualTo("1, Broadway");
+        assertThat(properties.getProperty("person.addresses[2].town")).isEqualTo("NY");
+        assertThat(properties.getProperty("vehicle.kind")).isEqualTo("911");
+        assertThat(properties.getProperty("vehicle.brand")).isEqualTo("Porsche");
+        assertThat(properties.getProperty("creditCards[0]")).isEqualTo("visa");
+        assertThat(properties.getProperty("creditCards[1]")).isEqualTo("mastercard");
+    }
+}

--- a/gravitee-node-container/src/test/resources/conf/gravitee-override.yml
+++ b/gravitee-node-container/src/test/resources/conf/gravitee-override.yml
@@ -1,0 +1,15 @@
+person:
+    name: Hank Moody
+    addresses:
+        - {}
+        - town: Hollywood, LA
+        - street: 1, Broadway
+          town: NY
+    emails:
+        - hanky@hotmail.com
+vehicle:
+    kind: 911
+    brand: Porsche
+creditCards:
+    - {}
+    - mastercard

--- a/gravitee-node-container/src/test/resources/conf/gravitee.yml
+++ b/gravitee-node-container/src/test/resources/conf/gravitee.yml
@@ -1,0 +1,13 @@
+person:
+    name: Hank
+    age: 42
+    single: false
+    addresses:
+        - street: Venice Beach
+          town: Los Angeles
+        - street: 1st Avenue
+          town: Hollywood
+    emails:
+        - hanky@gmail.com
+creditCards:
+    - visa


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/ARCHI-380

**Description**

Allow merging gravitee.yml

left.yml
```yaml
person:
    name: Hank
    age: 42
    single: false
    addresses:
        - street: Venice Beach
           town: Los Angeles
        - street: 1st Avenue
           town: Hollywood
    emails:
        - hanky@gmail.com
creditCards:
    - visa
```

right.yml
```yaml
person:
    name: Hank Moody               # override
    addresses:
        - {}                                      # skip
        - town: Hollywood, LA.     # partial override
        - street: 1, Broadway        # append
          town: NY
    emails:
        - hanky@hotmail.com.     # override
vehicle:                                      # add
    kind: 911
    brand: Porsche
creditCards:
    - {}                                         # skip
    - mastercard                        # append
```

merged.yml
```yaml
person:
    name: Hank Moody
    addresses:
        - street: Venice Beach
           town: Los Angeles
        - street: 1st Avenue
           town: Hollywood, LA
        - street: 1, Broadway
           town: NY
    emails:
        - hanky@hotmail.com
vehicle:
    kind: 911
    brand: Porsche
creditCards:
    - visa
    - mastercard
```

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

