### PR TITLE
fix: update parent pom version in redis cache implementation

### DIFF
--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>6.0.4</version>
+        <version>6.1.0</version>
     </parent>
 
     <artifactId>gravitee-node-cache-plugin-redis</artifactId>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.0-fix-redis-cache-pom-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.2.0-fix-redis-cache-pom-version-SNAPSHOT/gravitee-node-6.2.0-fix-redis-cache-pom-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
