### PR TITLE
feat: add capability to retrieve product name early during startup

### DIFF
--- a/gravitee-node-container/src/main/java/io/gravitee/node/container/GraviteeProductInitializer.java
+++ b/gravitee-node-container/src/main/java/io/gravitee/node/container/GraviteeProductInitializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.container;
+
+import io.gravitee.node.api.Node;
+
+/**
+ *
+ * Interface to implement by the products to identify uniquely who they are. It allows self-awareness at the highest level as it inherits from {@link io.gravitee.node.container.ContainerInitializer}       .
+ *
+ * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface GraviteeProductInitializer extends ContainerInitializer {
+    /**
+     * <p>Identify gravitee product name (gio-apim-gateway, gio-am-management...). It must be unique across all Gravitee products.</p>
+     *
+     * It should match the value of {@link Node#application()}
+     * @return the unique product name
+     */
+    String productName();
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-353

**Description**

Add a new interface that can be registered very soon in the booting process and allow product self awareness.

`gravitee-cloud-initializer` can use to configure cloud settings depending on the connecting product. 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.3.0-archi-352-identify-workload-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.3.0-archi-352-identify-workload-SNAPSHOT/gravitee-node-6.3.0-archi-352-identify-workload-SNAPSHOT.zip)
  <!-- Version placeholder end -->
