### PR TITLE
feat(http2): allows changing http2 multiplexing

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
@@ -119,7 +119,8 @@ public class VertxHttpClientFactory {
             options
                 .setProtocolVersion(HttpVersion.HTTP_2)
                 .setHttp2ClearTextUpgrade(httpOptions.isClearTextUpgrade())
-                .setHttp2MaxPoolSize(httpOptions.getMaxConcurrentConnections());
+                .setHttp2MaxPoolSize(httpOptions.getMaxConcurrentConnections())
+                .setHttp2MultiplexingLimit(httpOptions.getHttp2MultiplexingLimit());
         }
 
         final URL target = buildUrl(defaultTarget);

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
@@ -35,6 +35,7 @@ public class VertxHttpClientOptions implements Serializable {
     @Serial
     private static final long serialVersionUID = -7061411805967594667L;
 
+    public static final int DEFAULT_HTTP2_MULTIPLEXING_LIMIT = -1;
     public static final long DEFAULT_IDLE_TIMEOUT = 60000;
     public static final long DEFAULT_KEEP_ALIVE_TIMEOUT = 30000;
     public static final long DEFAULT_CONNECT_TIMEOUT = 5000;
@@ -48,6 +49,7 @@ public class VertxHttpClientOptions implements Serializable {
     public static final boolean DEFAULT_CLEAR_TEXT_UPGRADE = true;
     public static final VertxHttpProtocolVersion DEFAULT_PROTOCOL_VERSION = VertxHttpProtocolVersion.HTTP_1_1;
 
+    private int http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
     private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
     private long keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
     private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactoryTest.java
@@ -55,6 +55,7 @@ class VertxHttpClientFactoryTest {
             .version(HTTP_2)
             .pipelining(false)
             .clearTextUpgrade(true)
+            .http2MultiplexingLimit(-1)
             .build();
         final VertxHttpProxyOptions proxyOptions = VertxHttpProxyOptions
             .builder()


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-6471

**Description**

allows changing http2 multiplexing limit

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.5-APIM-6471-grpc-large-payloads-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.0.5-APIM-6471-grpc-large-payloads-SNAPSHOT/gravitee-node-6.0.5-APIM-6471-grpc-large-payloads-SNAPSHOT.zip)
  <!-- Version placeholder end -->
