### PR TITLE
fix: missing default builder on http client options

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
@@ -49,15 +49,36 @@ public class VertxHttpClientOptions implements Serializable {
     public static final boolean DEFAULT_CLEAR_TEXT_UPGRADE = true;
     public static final VertxHttpProtocolVersion DEFAULT_PROTOCOL_VERSION = VertxHttpProtocolVersion.HTTP_1_1;
 
+    @Builder.Default
     private int http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
+
+    @Builder.Default
     private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
+
+    @Builder.Default
     private long keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
+
+    @Builder.Default
     private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+
+    @Builder.Default
     private boolean keepAlive = DEFAULT_KEEP_ALIVE;
+
+    @Builder.Default
     private long readTimeout = DEFAULT_READ_TIMEOUT;
+
+    @Builder.Default
     private boolean pipelining = DEFAULT_PIPELINING;
+
+    @Builder.Default
     private int maxConcurrentConnections = DEFAULT_MAX_CONCURRENT_CONNECTIONS;
+
+    @Builder.Default
     private boolean useCompression = DEFAULT_USE_COMPRESSION;
+
+    @Builder.Default
     private boolean clearTextUpgrade = DEFAULT_CLEAR_TEXT_UPGRADE;
+
+    @Builder.Default
     private VertxHttpProtocolVersion version = DEFAULT_PROTOCOL_VERSION;
 }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpProxyOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpProxyOptions.java
@@ -49,5 +49,6 @@ public class VertxHttpProxyOptions implements Serializable {
 
     private String password;
 
+    @Builder.Default
     private VertxHttpProxyType type = VertxHttpProxyType.HTTP;
 }

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactoryTest.java
@@ -55,7 +55,6 @@ class VertxHttpClientFactoryTest {
             .version(HTTP_2)
             .pipelining(false)
             .clearTextUpgrade(true)
-            .http2MultiplexingLimit(-1)
             .build();
         final VertxHttpProxyOptions proxyOptions = VertxHttpProxyOptions
             .builder()


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-6471

**Description**

This is an additional fix to APIM°6471. This PR adds missing default builders that can cause an exception when using the `VertxHttpClientOption` builder because the default value of -1 is ignored and replaced with 0 which is forbidden by vertx.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.6-fix-missing-builder-default-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.0.6-fix-missing-builder-default-SNAPSHOT/gravitee-node-6.0.6-fix-missing-builder-default-SNAPSHOT.zip)
  <!-- Version placeholder end -->
