### PR TITLE
fix: return unhealthy result when a filtered prob is not found

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/ProbeEvaluator.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/ProbeEvaluator.java
@@ -1,6 +1,7 @@
 package io.gravitee.node.api.healthcheck;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -17,4 +18,13 @@ public interface ProbeEvaluator {
      * @return a {@link CompletableFuture} with the map of all evaluated probes.
      */
     CompletableFuture<Map<Probe, Result>> evaluate();
+
+    /**
+     * Same as {@link ProbeEvaluator#evaluate(Set)} but only for the probes id given
+     * In case a {@link Probe} is cacheable, the probe will be checked again only if the time elapsed since the last evaluation is above a particular threshold.
+     *
+     * @param probeIds the ids of the probes to evaluate
+     * @return a {@link CompletableFuture} with the map of all evaluated probes.
+     */
+    CompletableFuture<Map<Probe, Result>> evaluate(final Set<String> probeIds);
 }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
@@ -7,6 +7,7 @@ import io.gravitee.node.api.healthcheck.Result;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,11 @@ public class DefaultProbeEvaluator implements ProbeEvaluator {
 
     @Override
     public CompletableFuture<Map<Probe, Result>> evaluate() {
+        return evaluate(Set.of());
+    }
+
+    @Override
+    public CompletableFuture<Map<Probe, Result>> evaluate(final Set<String> probeIds) {
         final long now = Instant.now().toEpochMilli();
         final long elapsedTime = lastEvaluation != null ? now - lastEvaluation : Long.MAX_VALUE;
 
@@ -38,6 +44,7 @@ public class DefaultProbeEvaluator implements ProbeEvaluator {
         final List<CompletableFuture<Void>> collect =
             this.probeManager.getProbes()
                 .stream()
+                .filter(probe -> probeIds == null || probeIds.isEmpty() || probeIds.contains(probe.id()))
                 .map(probe -> {
                     if (probe.isCacheable()) {
                         if (elapsedTime < cacheDurationMs && lastProbeResults.containsKey(probe)) {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-412

**Description**

When a probe is requested on the /health endpoint, if this probe doesn't exist, the endpoint returns 200 SUCCESS instead of an error. This PR attempts to fix this issue.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

