### PR TITLE
fix: return empty array of accepted issuers in trust manager

### DIFF
--- a/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/x509/RefreshableX509TrustManagerDelegator.java
+++ b/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/x509/RefreshableX509TrustManagerDelegator.java
@@ -79,7 +79,10 @@ public class RefreshableX509TrustManagerDelegator extends X509ExtendedTrustManag
     @Override
     public X509Certificate[] getAcceptedIssuers() {
         X509ExtendedTrustManager trustManager = this.delegate;
-        return trustManager != null ? trustManager.getAcceptedIssuers() : null;
+        if (trustManager != null) {
+            return trustManager.getAcceptedIssuers();
+        }
+        return new X509Certificate[] {};
     }
 
     @Override


### PR DESCRIPTION
**Issue**

APIM-6628

**Description**

returned an empty array instead of null prevent NPE that allow the mTLS call to succeed.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.4.3-APIM-6628-fix-mtls-error-when-no-truststore-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.4.3-APIM-6628-fix-mtls-error-when-no-truststore-SNAPSHOT/gravitee-node-6.4.3-APIM-6628-fix-mtls-error-when-no-truststore-SNAPSHOT.zip)
  <!-- Version placeholder end -->
