### PR TITLE
fix: return empty array of accepted issuers in trust manager

### DIFF
--- a/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/x509/RefreshableX509TrustManagerDelegator.java
+++ b/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/x509/RefreshableX509TrustManagerDelegator.java
@@ -79,7 +79,10 @@ public class RefreshableX509TrustManagerDelegator extends X509ExtendedTrustManag
     @Override
     public X509Certificate[] getAcceptedIssuers() {
         X509ExtendedTrustManager trustManager = this.delegate;
-        return trustManager != null ? trustManager.getAcceptedIssuers() : null;
+        if (trustManager != null) {
+            return trustManager.getAcceptedIssuers();
+        }
+        return new X509Certificate[] {};
     }
 
     @Override


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6628

**Description**

Backport

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.7-APIM-6628-backport-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.0.7-APIM-6628-backport-SNAPSHOT/gravitee-node-6.0.7-APIM-6628-backport-SNAPSHOT.zip)
  <!-- Version placeholder end -->
