### PR TITLE
fix: removed stacktrace from periodic error message

### DIFF
--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/handler/NodeMonitoringEventHandler.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/handler/NodeMonitoringEventHandler.java
@@ -80,7 +80,11 @@ public class NodeMonitoringEventHandler extends AbstractService<NodeMonitoringEv
                         .createOrUpdate(convert(message.content()))
                         .ignoreElement()
                         .onErrorResumeNext(throwable -> {
-                            log.error("Unable to process node infos message", throwable);
+                            if (log.isDebugEnabled()) {
+                                log.error("Unable to process node infos message", throwable);
+                            } else {
+                                log.error("Unable to process node infos message, ex={}", throwable.toString());
+                            }
                             return Completable.complete();
                         })
                         .subscribe();
@@ -96,7 +100,11 @@ public class NodeMonitoringEventHandler extends AbstractService<NodeMonitoringEv
                         .createOrUpdate(convert(message.content()))
                         .ignoreElement()
                         .onErrorResumeNext(throwable -> {
-                            log.error("Unable to process health check message", throwable);
+                            if (log.isDebugEnabled()) {
+                                log.error("Unable to process health check message", throwable);
+                            } else {
+                                log.error("Unable to process health check message, ex={}", throwable.toString());
+                            }
                             return Completable.complete();
                         })
                         .subscribe();
@@ -112,7 +120,11 @@ public class NodeMonitoringEventHandler extends AbstractService<NodeMonitoringEv
                         .createOrUpdate(convert(message.content()))
                         .ignoreElement()
                         .onErrorResumeNext(throwable -> {
-                            log.error("Unable to process monitor message", throwable);
+                            if (log.isDebugEnabled()) {
+                                log.error("Unable to process monitor message", throwable);
+                            } else {
+                                log.error("Unable to process monitor message, ex={}", throwable.toString());
+                            }
                             return Completable.complete();
                         })
                         .subscribe();


### PR DESCRIPTION
fixes AM-3909 - In preparation for introducing Degraded Mode, we noticed a flood of the same messages with useless stack traces. By default, this keeps them on one line. To revert this, the log level can be set to DEBUG.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.4.4-fix-AM-3909-too-verbose-syncmanager-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.4.4-fix-AM-3909-too-verbose-syncmanager-SNAPSHOT/gravitee-node-6.4.4-fix-AM-3909-too-verbose-syncmanager-SNAPSHOT.zip)
  <!-- Version placeholder end -->
