### PR TITLE
fix: make redis cache pool settings configurable

### DIFF
--- a/gravitee-node-cache/README.adoc
+++ b/gravitee-node-cache/README.adoc
@@ -48,6 +48,192 @@ A basic example:
 </hazelcast>
 ```
 
+=== Redis
+
+The *Redis Plugin* is entirely relying on Redis implementation. It allows creating a remote cache using Redis.
+
+==== Configuration
+
+All the specific configurations are located under the `cache.redis` attribute.
+
+.Redis Standalone options
+|===
+|Parameter |Default |Description
+
+|host
+|localhost
+|
+
+|port
+|6379
+|
+
+|password
+|
+|
+
+|maxPoolSize
+|6
+|the maximum size of the connection pool.
+
+|maxPoolWaiting
+|24
+|the maximum number of requests waiting for a connection from the pool
+
+|poolCleanerInterval
+|30000
+|how often the connection pool will be cleaned. (in millis)
+
+|poolRecycleTimeout
+|18000
+|how long a connection can stay unused before it is recycled during connection pool cleaning (in millis)
+
+|maxWaitingHandlers
+|2048
+|how much backlog you're willing to accept
+|===
+
+.Redis Sentinel options
+|===
+|Parameter |Default |Description
+
+|sentinel.nodes
+|
+|List of sentinels with host and port
+
+|sentinel.master
+|
+|mandatory when using Sentinel
+
+|password
+|
+|
+|===
+
+.Redis SSL options
+|===
+|Parameter |Default |Description
+
+|ssl
+|false
+|
+
+|trustAll
+|true
+|Default value is true for backward compatibility but keep in mind that this is not a good practice and you should set to false and configure a truststore
+
+|hostnameVerificationAlgorithm
+|NONE
+|Default value is NONE for backward compatibility, supports `NONE`, `HTTPS`, `LDAPS`
+
+|tlsProtocols
+|See https://vertx.io/docs/vertx-core/java/#_configuring_tls_protocol_versions[Vert.x doc]
+|List of TLS protocols to allow comma separated.
+
+|tlsCiphers
+|See https://vertx.io/docs/vertx-core/java/#_configuring_the_cipher_suite[Vert.x doc]
+|List of TLS ciphers to allow comma separated.
+
+|alpn
+|false
+|
+
+|openssl
+|false
+|Used to rely on OpenSSL Engine instead of default JDK SSL Engine
+
+|keystore
+|
+|Configuration for Mutual TLS. The keystore is used to select the client certificate to send to the backend server when connecting. See <<keystore-table>>
+
+|truststore
+|
+|Configuration for the truststore. The truststore is used to validate the server’s certificate. See <<truststore-table>>
+|===
+
+
+[#keystore-table]
+.Redis SSL keystore options (client certificate, Mutual TLS)
+|===
+|Parameter |Default |Description
+|type
+|
+|Supports `jks`, `pem`, `pkcs12`
+
+|path
+|
+|A path is required if certificate's type is jks or pkcs12
+
+|password
+|
+|
+
+|alias
+|
+|
+
+|certificates
+|
+|List of certificates with cert and key. Certificates are required if keystore's type is pem
+|===
+
+[#truststore-table]
+.Redis SSL truststore options
+|===
+|Parameter |Default |Description
+|type
+|
+|Supports `jks`, `pem`, `pkcs12`
+
+|path
+|
+|
+
+|password
+|
+|
+
+|alias
+|
+|
+|===
+
+```yaml
+cache:
+  type: redis
+  redis:
+    host: localhost
+    port: 6379
+    password: ***
+    ssl: false
+    #maxPoolSize: 6
+    #maxPoolWaiting: 24
+    #poolCleanerInterval: 30000
+    #poolRecycleTimeout: 18000
+    #maxWaitingHandlers: 2048
+    ## Sentinel mode settings (optional)
+    # sentinel:
+    #   master: mymaster
+    #   password: ***
+    #   nodes:
+    #     host: host
+    #     port: 6379
+    ## SSL options  (optional if ssl is false)
+    #hostnameVerificationAlgorithm: NONE
+    #trustAll: false
+    #keystore:
+    #  type: PKCS12
+    #  path: /path/to/pkcs.12
+    #  password: ***
+    #  keyPassword: ***
+    #  alias: certalias
+    #truststore:
+    #  type: PKCS12
+    #  path: /path/to/pkcs.12
+    #  password: ***
+    #  alias: certalias
+```
+
 == Usage
 
 In order to use the Cache feature, you need to inject the `CacheManager` into you component, and then use it. See JavaDoc in `io.gravitee.node.api.cache.CacheManager` for more details.

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisConfiguration.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisConfiguration.java
@@ -28,4 +28,9 @@ public class RedisConfiguration {
     private HostAndPort hostAndPort;
     private SentinelConfiguration sentinelConfiguration;
     private SslOptions sslConfiguration;
+    private Integer maxPoolSize;
+    private Integer maxPoolWaiting;
+    private Integer poolCleanerInterval;
+    private Integer poolRecycleTimeout;
+    private Integer maxWaitingHandlers;
 }

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisConfigurationProvider.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisConfigurationProvider.java
@@ -43,6 +43,11 @@ public class RedisConfigurationProvider {
     public static final String HOST_KEY = "host";
     public static final String PASSWORD_KEY = "password";
     public static final String PORT_KEY = "port";
+    public static final String MAX_POOL_SIZE_KEY = "maxPoolSize";
+    public static final String MAX_POOL_WAITING_KEY = "maxPoolWaiting";
+    public static final String POOL_CLEANER_INTERVAL_KEY = "poolCleanerInterval";
+    public static final String POOL_RECYCLE_TIMEOUT_KEY = "poolRecycleTimeout";
+    public static final String MAX_WAITING_HANDLERS_KEY = "maxWaitingHandlers";
 
     private RedisConfigurationProvider() {
         // no op
@@ -90,6 +95,12 @@ public class RedisConfigurationProvider {
             sslConfig.setTrustStore(loadTrustStore(environment, propertiesPrefix + ".truststore"));
             config.setSslConfiguration(sslConfig);
         }
+
+        config.setMaxPoolSize(environment.getProperty(propertiesPrefix + "." + MAX_POOL_SIZE_KEY, Integer.class));
+        config.setMaxPoolWaiting(environment.getProperty(propertiesPrefix + "." + MAX_POOL_WAITING_KEY, Integer.class));
+        config.setPoolCleanerInterval(environment.getProperty(propertiesPrefix + "." + POOL_CLEANER_INTERVAL_KEY, Integer.class));
+        config.setPoolRecycleTimeout(environment.getProperty(propertiesPrefix + "." + POOL_RECYCLE_TIMEOUT_KEY, Integer.class));
+        config.setMaxWaitingHandlers(environment.getProperty(propertiesPrefix + "." + MAX_WAITING_HANDLERS_KEY, Integer.class));
 
         return config;
     }

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisOptionsFactory.java
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/src/main/java/io/gravitee/node/plugin/cache/redis/configuration/RedisOptionsFactory.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.node.plugin.cache.redis.configuration;
 
+import static java.util.Optional.ofNullable;
+
 import io.gravitee.node.vertx.client.ssl.SslOptions;
 import io.gravitee.node.vertx.client.tcp.VertxTcpClientFactory;
 import io.vertx.redis.client.RedisClientType;
 import io.vertx.redis.client.RedisOptions;
 import io.vertx.redis.client.RedisRole;
 import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
@@ -71,8 +74,13 @@ public class RedisOptionsFactory {
             VertxTcpClientFactory.configureSslClientOption(options.getNetClientOptions(), sslConfiguration);
         }
 
-        // Set max waiting handlers high enough to manage high throughput since we are not using the pooled mode
-        options.setMaxWaitingHandlers(1024);
+        options.setPoolName("cache-redis-" + UUID.randomUUID());
+        ofNullable(configuration.getMaxPoolSize()).ifPresent(options::setMaxPoolSize);
+        ofNullable(configuration.getMaxPoolWaiting()).ifPresent(options::setMaxPoolWaiting);
+        ofNullable(configuration.getPoolCleanerInterval()).ifPresent(options::setPoolCleanerInterval);
+        ofNullable(configuration.getPoolRecycleTimeout()).ifPresent(options::setPoolRecycleTimeout);
+        ofNullable(configuration.getMaxWaitingHandlers()).ifPresent(options::setMaxWaitingHandlers);
+
         return options;
     }
 }


### PR DESCRIPTION
related to AM-3974


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.4.4-am-3974-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.4.4-am-3974-SNAPSHOT/gravitee-node-6.4.4-am-3974-SNAPSHOT.zip)
  <!-- Version placeholder end -->
