### PR TITLE
fix(metrics): hold strong reference to probes results in micrometer gauge

### DIFF
--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
@@ -72,4 +72,8 @@ public class DefaultProbeEvaluator implements ProbeEvaluator {
                 }
             });
     }
+
+    public Map<Probe, Result> getCachedResults() {
+        return lastProbeResults;
+    }
 }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/micrometer/NodeHealthCheckMicrometerHandler.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/micrometer/NodeHealthCheckMicrometerHandler.java
@@ -41,7 +41,7 @@ public class NodeHealthCheckMicrometerHandler implements MeterBinder {
         try {
             for (Map.Entry<Probe, Result> entry : probeRegistry.evaluate().get().entrySet()) {
                 Gauge
-                    .builder("node", entry, e -> e.getValue().isHealthy() ? 1d : 0d)
+                    .builder("node", probeRegistry, e -> e.getCachedResults().get(entry.getKey()).isHealthy() ? 1d : 0d)
                     .tag("probe", entry.getKey().id())
                     .description("The health-check probes of the node")
                     .baseUnit("health")


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/10070

**Description**

probes results in NaN for prometheus micrometer. It's because we are not holding a strong reference to the state object
[doc](https://docs.micrometer.io/micrometer/reference/concepts/gauges.html#_why_is_my_gauge_reporting_nan_or_disappearing)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.4.5-APIM-7113-prometheus-metrics-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.4.5-APIM-7113-prometheus-metrics-SNAPSHOT/gravitee-node-6.4.5-APIM-7113-prometheus-metrics-SNAPSHOT.zip)
  <!-- Version placeholder end -->
