### PR TITLE
fix: declare all modules in dependency management

### DIFF
--- a/gravitee-node-cache/gravitee-node-cache-common/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-common/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-handler/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-handler/pom.xml
@@ -35,25 +35,21 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-plugins-service</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-management</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-reporter</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/pom.xml
@@ -40,13 +40,11 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-cache-common</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- Hazelcast -->

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/pom.xml
@@ -42,21 +42,12 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-vertx</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-node-cache/gravitee-node-cache-plugin-standalone/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-standalone/pom.xml
@@ -40,13 +40,11 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-cache-common</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/gravitee-node-certificates/pom.xml
+++ b/gravitee-node-certificates/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Spring -->

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/pom.xml
@@ -35,25 +35,21 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-plugins-service</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-management</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-reporter</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- Hazelcast -->

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/gravitee-node-cluster/pom.xml
+++ b/gravitee-node-cluster/pom.xml
@@ -33,7 +33,7 @@
 
     <modules>
         <module>gravitee-node-cluster-plugin-handler</module>
-        <module>gravitee-node-cluster-plugin-standalone</module>
         <module>gravitee-node-cluster-plugin-hazelcast</module>
+        <module>gravitee-node-cluster-plugin-standalone</module>
     </modules>
 </project>

--- a/gravitee-node-container/pom.xml
+++ b/gravitee-node-container/pom.xml
@@ -35,60 +35,50 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-plugins-service</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-monitoring</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-cluster-plugin-handler</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-cache-common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-cache-plugin-handler</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-management</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-reporter</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-kubernetes</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-license</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-node-license/pom.xml
+++ b/gravitee-node-license/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.gravitee.common</groupId>
@@ -44,7 +43,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-management</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Licensing -->

--- a/gravitee-node-management/pom.xml
+++ b/gravitee-node-management/pom.xml
@@ -35,13 +35,11 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-vertx</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Vert.x -->

--- a/gravitee-node-monitoring/pom.xml
+++ b/gravitee-node-monitoring/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -51,7 +50,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-management</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <!-- Test dependencies -->
         <dependency>
@@ -62,7 +60,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-cluster-plugin-standalone</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gravitee-node-notifier/pom.xml
+++ b/gravitee-node-notifier/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/gravitee-node-reporter/pom.xml
+++ b/gravitee-node-reporter/pom.xml
@@ -35,13 +35,11 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-vertx</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-node-secrets/pom.xml
+++ b/gravitee-node-secrets/pom.xml
@@ -36,19 +36,4 @@
         <module>gravitee-node-secrets-service</module>
     </modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-secrets-api</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-secrets-plugin-handler</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
 </project>

--- a/gravitee-node-services/pom.xml
+++ b/gravitee-node-services/pom.xml
@@ -42,7 +42,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/gravitee-node-tracing/pom.xml
+++ b/gravitee-node-tracing/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-node-vertx/pom.xml
+++ b/gravitee-node-vertx/pom.xml
@@ -39,17 +39,14 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-tracing</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-certificates</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Vert.x -->

--- a/pom.xml
+++ b/pom.xml
@@ -286,13 +286,6 @@
                 <version>${guava.version}</version>
             </dependency>
 
-            <!-- Spring -->
-            <dependency>
-                <groupId>org.springframework.data</groupId>
-                <artifactId>spring-data-redis</artifactId>
-                <version>${spring-data-redis.version}</version>
-            </dependency>
-
             <!-- Hazelcast -->
             <dependency>
                 <groupId>com.hazelcast</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <properties>
         <gravitee-bom.version>8.1.0</gravitee-bom.version>
         <gravitee-common.version>3.3.3</gravitee-common.version>
-        <gravitee-plugin.version>4.1.0</gravitee-plugin.version>
+        <gravitee-plugin.version>4.2.0</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <gravitee-tracing-api.version>1.0.0</gravitee-tracing-api.version>
         <gravitee-kubernetes.version>3.1.0</gravitee-kubernetes.version>
@@ -95,17 +95,7 @@
             </dependency>
             <dependency>
                 <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-container</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-vertx</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-cluster-plugin-handler</artifactId>
+                <artifactId>gravitee-node-cache</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -120,32 +110,17 @@
             </dependency>
             <dependency>
                 <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-monitoring</artifactId>
+                <artifactId>gravitee-node-cache-plugin-hazelcast</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-management</artifactId>
+                <artifactId>gravitee-node-cache-plugin-redis</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-reporter</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-plugins</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-services</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-jetty</artifactId>
+                <artifactId>gravitee-node-cache-plugin-standalone</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -155,12 +130,77 @@
             </dependency>
             <dependency>
                 <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-cluster</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-cluster-plugin-handler</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-cluster-plugin-hazelcast</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-cluster-plugin-standalone</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-container</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-jetty</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
                 <artifactId>gravitee-node-kubernetes</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-secrets-service</artifactId>
+                <artifactId>gravitee-node-license</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-management</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-monitoring</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-notifier</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-plugins</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-plugins-service</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-reporter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-secrets</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -170,7 +210,32 @@
             </dependency>
             <dependency>
                 <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-notifier</artifactId>
+                <artifactId>gravitee-node-secrets-service</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-services</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node.services</groupId>
+                <artifactId>gravitee-node-services-initializer</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node.services</groupId>
+                <artifactId>gravitee-node-services-upgrader</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-tracing</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-vertx</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <!-- Gravitee.io -->


### PR DESCRIPTION
**Issue**

N/A

**Description**

To allow importing gravitee-node in the dependency management section of another project's pom.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.4.6-fix-dependency-management-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.4.6-fix-dependency-management-SNAPSHOT/gravitee-node-6.4.6-fix-dependency-management-SNAPSHOT.zip)
  <!-- Version placeholder end -->
