### PR TITLE
fix: apply keep alive to http/2 connections

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
@@ -119,6 +119,7 @@ public class VertxHttpClientFactory {
             options
                 .setProtocolVersion(HttpVersion.HTTP_2)
                 .setHttp2ClearTextUpgrade(httpOptions.isClearTextUpgrade())
+                .setHttp2KeepAliveTimeout((int) httpOptions.getKeepAliveTimeout() / 1000)
                 .setHttp2MaxPoolSize(httpOptions.getMaxConcurrentConnections())
                 .setHttp2MultiplexingLimit(httpOptions.getHttp2MultiplexingLimit());
         }


### PR DESCRIPTION
**Issue**

keep alive timeout was not set for http2 connection.

**Description**



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.5.1-fix-http2-keepalive-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.5.1-fix-http2-keepalive-SNAPSHOT/gravitee-node-6.5.1-fix-http2-keepalive-SNAPSHOT.zip)
  <!-- Version placeholder end -->
