### PR TITLE
feat: add metadata property to NodeInfos

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/infos/NodeInfos.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/infos/NodeInfos.java
@@ -17,13 +17,18 @@ package io.gravitee.node.api.infos;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class NodeInfos implements Serializable {
 
     private String id;
@@ -39,108 +44,5 @@ public class NodeInfos implements Serializable {
     private int port;
     private String tenant;
     private Set<PluginInfos> pluginInfos;
-
-    public String getHostname() {
-        return hostname;
-    }
-
-    public void setHostname(String hostname) {
-        this.hostname = hostname;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getIp() {
-        return ip;
-    }
-
-    public void setIp(String ip) {
-        this.ip = ip;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    public void setPort(int port) {
-        this.port = port;
-    }
-
-    public List<String> getTags() {
-        return tags;
-    }
-
-    public void setTags(List<String> tags) {
-        this.tags = tags;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public Set<PluginInfos> getPluginInfos() {
-        return pluginInfos;
-    }
-
-    public void setPluginInfos(Set<PluginInfos> pluginInfos) {
-        this.pluginInfos = pluginInfos;
-    }
-
-    public String getTenant() {
-        return tenant;
-    }
-
-    public void setTenant(String tenant) {
-        this.tenant = tenant;
-    }
-
-    public NodeStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(NodeStatus status) {
-        this.status = status;
-    }
-
-    public String getJdkVersion() {
-        return jdkVersion;
-    }
-
-    public void setJdkVersion(String jdkVersion) {
-        this.jdkVersion = jdkVersion;
-    }
-
-    public long getEvaluatedAt() {
-        return evaluatedAt;
-    }
-
-    public void setEvaluatedAt(long evaluatedAt) {
-        this.evaluatedAt = evaluatedAt;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getApplication() {
-        return application;
-    }
-
-    public void setApplication(String application) {
-        this.application = application;
-    }
+    private Map<String, String> metadata;
 }

--- a/gravitee-node-monitoring/pom.xml
+++ b/gravitee-node-monitoring/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>gravitee-node-cluster-plugin-standalone</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/NodeMonitoringConfiguration.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/NodeMonitoringConfiguration.java
@@ -33,11 +33,13 @@ import io.gravitee.node.monitoring.infos.NodeInfosService;
 import io.gravitee.node.monitoring.monitor.NodeMonitorManagementEndpoint;
 import io.gravitee.node.monitoring.monitor.NodeMonitorService;
 import io.gravitee.plugin.alert.AlertEventProducer;
+import io.gravitee.plugin.core.api.PluginRegistry;
 import io.vertx.core.Vertx;
 import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
  * @author Jeoffre HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -126,8 +128,8 @@ public class NodeMonitoringConfiguration {
     }
 
     @Bean
-    public NodeInfosService nodeInfosService() {
-        return new NodeInfosService();
+    public NodeInfosService nodeInfosService(PluginRegistry pluginRegistry, ConfigurableEnvironment environment, Node node, Vertx vertx) {
+        return new NodeInfosService(pluginRegistry, environment, node, vertx);
     }
 
     @Bean

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/infos/NodeInfosServiceTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/infos/NodeInfosServiceTest.java
@@ -1,0 +1,93 @@
+package io.gravitee.node.monitoring.infos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.infos.NodeInfos;
+import io.gravitee.plugin.core.api.PluginManifest;
+import io.gravitee.plugin.core.api.PluginRegistry;
+import io.vertx.core.Vertx;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+public class NodeInfosServiceTest {
+
+    protected static final String NODE_ID = "NODE_ID";
+
+    @Mock
+    private PluginRegistry pluginRegistry;
+
+    @Mock
+    private Node node;
+
+    private final MockEnvironment environment = new MockEnvironment();
+
+    @Test
+    @SneakyThrows
+    void should_start_the_service() {
+        environment.setProperty("http.port", "8888");
+        environment.setProperty("tags", "tag1,tag2");
+        environment.setProperty("metadata[0]_id", "#id");
+        environment.setProperty("metadata[1]_foo", "bar");
+        when(node.id()).thenReturn(NODE_ID);
+        when(node.application()).thenReturn("APPLICATION");
+        mockPluginRegistry();
+
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicReference<NodeInfos> nodeInfosRef = new AtomicReference<>();
+        Vertx vertx = Vertx.vertx();
+        vertx
+            .eventBus()
+            .localConsumer(
+                NodeInfosService.GIO_NODE_INFOS_BUS,
+                event -> {
+                    nodeInfosRef.set((NodeInfos) event.body());
+                    latch.countDown();
+                }
+            );
+        final NodeInfosService cut = new NodeInfosService(pluginRegistry, environment, node, vertx);
+
+        cut.doStart();
+
+        latch.await(100, TimeUnit.MILLISECONDS);
+        NodeInfos nodeInfos = nodeInfosRef.get();
+        assertThat(nodeInfos).isNotNull();
+        assertThat(nodeInfos.getId()).isEqualTo(NODE_ID);
+        assertThat(nodeInfos.getApplication()).isEqualTo("APPLICATION");
+        assertThat(nodeInfos.getPort()).isEqualTo(8888);
+        assertThat(nodeInfos.getTags()).isEqualTo(List.of("tag1", "tag2"));
+        assertThat(nodeInfos.getPluginInfos()).isNotEmpty();
+        assertThat(nodeInfos.getVersion()).isNotNull();
+        assertThat(nodeInfos.getJdkVersion()).isNotNull();
+        assertThat(nodeInfos.getEvaluatedAt()).isNotNull();
+        assertThat(nodeInfos.getHostname()).isNotNull();
+        assertThat(nodeInfos.getIp()).isNotNull();
+        assertThat(nodeInfos.getMetadata()).isEqualTo(Map.of("id", "#id", "foo", "bar"));
+    }
+
+    private void mockPluginRegistry() {
+        final io.gravitee.plugin.core.api.Plugin alertPlugin = mock(io.gravitee.plugin.core.api.Plugin.class);
+        final PluginManifest alertPluginManifest = mock(PluginManifest.class);
+        lenient().when(alertPlugin.type()).thenReturn("alert");
+        lenient().when(alertPlugin.manifest()).thenReturn(alertPluginManifest);
+        final io.gravitee.plugin.core.api.Plugin notifierPlugin = mock(io.gravitee.plugin.core.api.Plugin.class);
+        final PluginManifest notifierPluginManifest = mock(PluginManifest.class);
+        lenient().when(notifierPlugin.type()).thenReturn("notifier");
+        lenient().when(notifierPlugin.manifest()).thenReturn(notifierPluginManifest);
+        lenient().when(pluginRegistry.plugins()).thenReturn(List.of(alertPlugin, notifierPlugin));
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/CJ-2542

**Description**

For the upgrade of Cloud gateways 30 days after control plane upgrade [EPIC](https://gravitee.atlassian.net/browse/CJ-2460) we need to link data plane deployment and registered nodes on cockpit side cockpit. 

This PR add a generic additionalInformation environment variable. 

Another [task on platform team side ](https://gravitee.atlassian.net/browse/TT-5930) will add the deploymentId on addtionalInformation of dataPlane.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.0-cj-2542-gateway-technical-id-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.0.0-cj-2542-gateway-technical-id-SNAPSHOT/gravitee-node-7.0.0-cj-2542-gateway-technical-id-SNAPSHOT.zip)
  <!-- Version placeholder end -->
