### PR TITLE
Archi 428

### DIFF
--- a/gravitee-node-container/src/main/java/io/gravitee/node/container/AbstractNode.java
+++ b/gravitee-node-container/src/main/java/io/gravitee/node/container/AbstractNode.java
@@ -28,6 +28,7 @@ import io.gravitee.node.monitoring.handler.NodeMonitoringEventHandler;
 import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
 import io.gravitee.node.monitoring.infos.NodeInfosService;
 import io.gravitee.node.monitoring.monitor.NodeMonitorService;
+import io.gravitee.node.opentelemetry.exporter.SpanExporterFactory;
 import io.gravitee.node.plugins.service.ServiceManager;
 import io.gravitee.node.reporter.ReporterManager;
 import io.gravitee.plugin.core.api.PluginRegistry;
@@ -134,6 +135,7 @@ public abstract class AbstractNode extends AbstractService<Node> implements Node
     public List<Class<? extends LifecycleComponent>> components() {
         List<Class<? extends LifecycleComponent>> components = new ArrayList<>();
 
+        components.add(SpanExporterFactory.class);
         components.add(PluginEventListener.class);
         components.add(PluginRegistry.class);
         components.add(NodeClusterService.class);

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/OpenTelemetryFactory.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/OpenTelemetryFactory.java
@@ -19,7 +19,7 @@ import io.gravitee.node.api.opentelemetry.InstrumenterTracerFactory;
 import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.api.opentelemetry.TracerFactory;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
-import io.gravitee.node.opentelemetry.exporter.ExporterFactory;
+import io.gravitee.node.opentelemetry.exporter.SpanExporterFactory;
 import io.gravitee.node.opentelemetry.tracer.OpenTelemetryTracer;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
@@ -54,7 +54,7 @@ public class OpenTelemetryFactory implements TracerFactory {
     private static final AttributeKey<String> ATTRIBUTE_KEY_SERVICE_NAMESPACE = AttributeKey.stringKey("service.namespace");
 
     private final OpenTelemetryConfiguration configuration;
-    private final ExporterFactory exporterFactory;
+    private final SpanExporterFactory spanExporterFactory;
 
     @Override
     public Tracer createTracer(
@@ -77,7 +77,7 @@ public class OpenTelemetryFactory implements TracerFactory {
 
             SdkTracerProvider tracerProvider = SdkTracerProvider
                 .builder()
-                .addSpanProcessor(BatchSpanProcessor.builder(exporterFactory.createSpanExporter()).build())
+                .addSpanProcessor(BatchSpanProcessor.builder(spanExporterFactory.getSpanExporter()).build())
                 .setResource(resource)
                 .build();
 

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/OTelExporterUtil.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/OTelExporterUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.node.opentelemetry.exporter;
 
 import java.net.URI;

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/tracing/VertxHttpSpanExporter.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/tracing/VertxHttpSpanExporter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.node.opentelemetry.exporter.tracing;
 
 import io.opentelemetry.exporter.internal.http.HttpExporter;

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/spring/OpenTelemetrySpringConfiguration.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/spring/OpenTelemetrySpringConfiguration.java
@@ -15,17 +15,14 @@
  */
 package io.gravitee.node.opentelemetry.spring;
 
-import io.gravitee.node.api.opentelemetry.InstrumenterTracerFactory;
 import io.gravitee.node.opentelemetry.OpenTelemetryFactory;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
-import io.gravitee.node.opentelemetry.exporter.ExporterFactory;
+import io.gravitee.node.opentelemetry.exporter.SpanExporterFactory;
 import io.gravitee.node.opentelemetry.tracer.instrumentation.internal.InternalInstrumenterTracerFactory;
 import io.gravitee.node.opentelemetry.tracer.instrumentation.vertx.VertxHttpInstrumenterTracerFactory;
 import io.vertx.core.Vertx;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
@@ -41,16 +38,16 @@ public class OpenTelemetrySpringConfiguration {
     }
 
     @Bean
-    public ExporterFactory exporterFactory(final OpenTelemetryConfiguration openTelemetryConfiguration, final Vertx vertx) {
-        return new ExporterFactory(openTelemetryConfiguration, vertx);
+    public SpanExporterFactory exporterFactory(final OpenTelemetryConfiguration openTelemetryConfiguration, final Vertx vertx) {
+        return new SpanExporterFactory(openTelemetryConfiguration, vertx);
     }
 
     @Bean
     public OpenTelemetryFactory openTelemetryFactory(
         final OpenTelemetryConfiguration openTelemetryConfiguration,
-        final ExporterFactory exporterFactory
+        final SpanExporterFactory spanExporterFactory
     ) {
-        return new OpenTelemetryFactory(openTelemetryConfiguration, exporterFactory);
+        return new OpenTelemetryFactory(openTelemetryConfiguration, spanExporterFactory);
     }
 
     @Bean

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracer.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracer.java
@@ -171,7 +171,7 @@ public class OpenTelemetryTracer extends AbstractService<Tracer> implements Trac
         if (currentContext != null) {
             W3CTraceContextPropagator
                 .getInstance()
-                .inject(currentContext, null, (carrier1, key, value) -> textMapSetter.accept(key, value));
+                .inject(currentContext, null, (nullCarrier, key, value) -> textMapSetter.accept(key, value));
         }
     }
 
@@ -180,7 +180,7 @@ public class OpenTelemetryTracer extends AbstractService<Tracer> implements Trac
         if (span instanceof OpenTelemetrySpan<?> openTelemetrySpan) {
             W3CTraceContextPropagator
                 .getInstance()
-                .inject(openTelemetrySpan.otelContext(), null, (carrier1, key, value) -> textMapSetter.accept(key, value));
+                .inject(openTelemetrySpan.otelContext(), null, (nullCarrier, key, value) -> textMapSetter.accept(key, value));
         }
     }
 }

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/OpenTelemetryTracerIntegrationTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/OpenTelemetryTracerIntegrationTest.java
@@ -22,7 +22,7 @@ import static org.awaitility.Awaitility.await;
 import io.gravitee.node.api.opentelemetry.internal.InternalRequest;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import io.gravitee.node.opentelemetry.configuration.Protocol;
-import io.gravitee.node.opentelemetry.exporter.ExporterFactory;
+import io.gravitee.node.opentelemetry.exporter.SpanExporterFactory;
 import io.gravitee.node.opentelemetry.testcontainers.JaegerAllInOne;
 import io.gravitee.node.opentelemetry.tracer.instrumentation.internal.InternalInstrumenterTracerFactory;
 import io.gravitee.node.opentelemetry.tracer.instrumentation.vertx.VertxHttpInstrumenterTracerFactory;
@@ -146,7 +146,7 @@ public class OpenTelemetryTracerIntegrationTest {
         final Vertx vertx,
         final OpenTelemetryConfiguration openTelemetryConfiguration
     ) {
-        return new OpenTelemetryFactory(openTelemetryConfiguration, new ExporterFactory(openTelemetryConfiguration, vertx));
+        return new OpenTelemetryFactory(openTelemetryConfiguration, new SpanExporterFactory(openTelemetryConfiguration, vertx));
     }
 
     @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-428

**Description**

Use a internal wrapper in ordre to share the underlying span exporter. The wrapper will be shuting down as long as the node.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.0-archi-428-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.0.0-archi-428-SNAPSHOT/gravitee-node-7.0.0-archi-428-SNAPSHOT.zip)
  <!-- Version placeholder end -->
