### PR TITLE
feat: addition of new feature key for entreprise-secret-manager pack

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -90,6 +90,7 @@ packs:
             - gravitee-en-secretprovider-vault
             - gravitee-en-secretprovider-aws
             - am-certificate-aws
+            - am-certificate-aws-cloudhsm
     enterprise-alert-engine:
         features:
             - alert-engine

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -1,6 +1,8 @@
 package io.gravitee.node.license;
 
-import static io.gravitee.node.api.license.License.*;
+import static io.gravitee.node.api.license.License.REFERENCE_ID_PLATFORM;
+import static io.gravitee.node.api.license.License.REFERENCE_TYPE_ORGANIZATION;
+import static io.gravitee.node.api.license.License.REFERENCE_TYPE_PLATFORM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -338,6 +340,7 @@ class DefaultLicenseFactoryTest {
             "gravitee-en-secretprovider-vault",
             "gravitee-en-secretprovider-aws",
             "am-certificate-aws",
+            "am-certificate-aws-cloudhsm",
             "apim-policy-graphql-ratelimit",
             "apim-policy-interops-a-idp",
             "apim-policy-interops-r-idp",


### PR DESCRIPTION
 this feature key is about the CloudHSM plugin in AccessManagement

fixes AM-4162
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.7.0-am-4162-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.7.0-am-4162-SNAPSHOT/gravitee-node-6.7.0-am-4162-SNAPSHOT.zip)
  <!-- Version placeholder end -->
