### PR TITLE
Add native kafka features pack

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -96,6 +96,12 @@ packs:
     oem:
         features:
             - oem-customization
+    native-kafka:
+        features:
+            - apim-native-kafka-reactor
+            - apim-native-kafka-policy-acl
+            - apim-native-kafka-policy-quota
+            - apim-native-kafka-policy-topic-mapping
 
 tiers:
     planet:


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7159

**Description**

Add a new pack of features for the kafka gateway . This pack is not part of any tier.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.0-apim-add-license-feature-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.0.0-apim-add-license-feature-SNAPSHOT/gravitee-node-7.0.0-apim-add-license-feature-SNAPSHOT.zip)
  <!-- Version placeholder end -->
