### PR TITLE
allow to configure unknown tier & pack in the license - 4.8.x

### DIFF
--- a/gravitee-node-license/pom.xml
+++ b/gravitee-node-license/pom.xml
@@ -70,6 +70,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/NodeLicenseServiceTest.java
@@ -70,7 +70,6 @@ class NodeLicenseServiceTest {
     @Test
     void shouldReturnTier() {
         when(tier.getString()).thenReturn("planet");
-        when(license.feature("tier")).thenReturn(Optional.of(tier));
         service.refresh();
         assertThat(service.getTier()).isEqualTo("planet");
     }
@@ -197,5 +196,52 @@ class NodeLicenseServiceTest {
         when(license.features()).thenReturn(Map.of("apim-api-designer", "included", "apim-bridge-gateway", "included"));
         service.refresh();
         assertThat(service.isFeatureEnabled("apim-api-designer")).isTrue();
+    }
+
+    @Test
+    void shouldNotFailIfUnknownTier() {
+        when(tier.getString()).thenReturn("unknown");
+        when(packs.getString()).thenReturn("enterprise-legacy-upgrade");
+        service.refresh();
+        assertThat(service.getTier()).isEqualTo("unknown");
+        assertThat(service.getPacks()).containsExactly("enterprise-legacy-upgrade");
+        assertThat(service.getFeatures()).containsExactlyInAnyOrder("apim-policy-xslt", "apim-policy-ws-security-authentication");
+    }
+
+    @Test
+    void shouldNotFailIfUnknownPack() {
+        when(tier.getString()).thenReturn("planet");
+        when(packs.getString()).thenReturn("unknown");
+        service.refresh();
+        assertThat(service.getTier()).isEqualTo("planet");
+        assertThat(service.getPacks())
+            .containsExactlyInAnyOrder("enterprise-features", "enterprise-legacy-upgrade", "enterprise-identity-provider", "unknown");
+        assertThat(service.getFeatures())
+            .containsExactlyInAnyOrder(
+                "apim-api-designer",
+                "apim-dcr-registration",
+                "apim-custom-roles",
+                "apim-audit-trail",
+                "apim-sharding-tags",
+                "apim-openid-connect-sso",
+                "apim-debug-mode",
+                "gravitee-risk-assessment",
+                "risk-assessment",
+                "apim-bridge-gateway",
+                "apim-policy-xslt",
+                "apim-policy-ws-security-authentication",
+                "am-idp-salesforce",
+                "am-idp-saml",
+                "am-idp-ldap",
+                "am-idp-kerberos",
+                "am-idp-azure-ad",
+                "am-idp-gateway-handler-saml",
+                "am-gateway-handler-saml-idp",
+                "am-idp-http-flow",
+                "http-flow-am-idp",
+                "am-idp-france-connect",
+                "am-idp-cas",
+                "cas-am-idp"
+            );
     }
 }

--- a/gravitee-node-license/src/test/resources/logback-test.xml
+++ b/gravitee-node-license/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="DEBUG" />
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>
+


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7159

**Description**

If a license is generated with a tier or a pack that has been defined for APIM 4.6 or more, we should ignore them instead of failing with a NPE.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.9.0-handle-not-existing-pack-in-license-4-8-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/4.9.0-handle-not-existing-pack-in-license-4-8-x-SNAPSHOT/gravitee-node-4.9.0-handle-not-existing-pack-in-license-4-8-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
