### PR TITLE
feat: allow mock secret provider to get secrets updated

### DIFF
--- a/gravitee-node-secrets/gravitee-secret-provider-mock/src/main/java/io/gravitee/node/secrets/plugin/mock/MockSecretProvider.java
+++ b/gravitee-node-secrets/gravitee-secret-provider-mock/src/main/java/io/gravitee/node/secrets/plugin/mock/MockSecretProvider.java
@@ -109,4 +109,8 @@ public class MockSecretProvider implements SecretProvider {
                 }
             });
     }
+
+    public void updateSecret(String name, String key, String value) {
+        this.configuration.getSecrets().put(name.concat(".").concat(key), value);
+    }
 }


### PR DESCRIPTION
**Issue**

Spotted a bug in secret resolution, need to update mock-secret-provider to allow a secret to have a new key

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

