### PR TITLE
fix: add more tcp client options

### DIFF
--- a/gravitee-node-api/pom.xml
+++ b/gravitee-node-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-api</artifactId>

--- a/gravitee-node-cache/gravitee-node-cache-common/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-common</artifactId>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-handler/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-handler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-plugin-handler</artifactId>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-hazelcast/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-plugin-hazelcast</artifactId>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-redis/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-redis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-plugin-redis</artifactId>

--- a/gravitee-node-cache/gravitee-node-cache-plugin-standalone/pom.xml
+++ b/gravitee-node-cache/gravitee-node-cache-plugin-standalone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cache</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache-plugin-standalone</artifactId>

--- a/gravitee-node-cache/pom.xml
+++ b/gravitee-node-cache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cache</artifactId>

--- a/gravitee-node-certificates/pom.xml
+++ b/gravitee-node-certificates/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-certificates</artifactId>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cluster</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cluster-plugin-handler</artifactId>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cluster</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cluster-plugin-hazelcast</artifactId>

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-cluster</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cluster-plugin-standalone</artifactId>

--- a/gravitee-node-cluster/pom.xml
+++ b/gravitee-node-cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-cluster</artifactId>

--- a/gravitee-node-container/pom.xml
+++ b/gravitee-node-container/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-container</artifactId>

--- a/gravitee-node-jetty/pom.xml
+++ b/gravitee-node-jetty/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-jetty</artifactId>

--- a/gravitee-node-kubernetes/pom.xml
+++ b/gravitee-node-kubernetes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-kubernetes</artifactId>

--- a/gravitee-node-license/pom.xml
+++ b/gravitee-node-license/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-license</artifactId>

--- a/gravitee-node-management/pom.xml
+++ b/gravitee-node-management/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-management</artifactId>

--- a/gravitee-node-monitoring/pom.xml
+++ b/gravitee-node-monitoring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-monitoring</artifactId>

--- a/gravitee-node-notifier/pom.xml
+++ b/gravitee-node-notifier/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-node</artifactId>
         <groupId>io.gravitee.node</groupId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-node-opentelemetry/pom.xml
+++ b/gravitee-node-opentelemetry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-opentelemetry</artifactId>

--- a/gravitee-node-plugins/gravitee-node-plugins-service/pom.xml
+++ b/gravitee-node-plugins/gravitee-node-plugins-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-plugins</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-plugins-service</artifactId>

--- a/gravitee-node-plugins/pom.xml
+++ b/gravitee-node-plugins/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-plugins</artifactId>

--- a/gravitee-node-reporter/pom.xml
+++ b/gravitee-node-reporter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-reporter</artifactId>

--- a/gravitee-node-secrets/gravitee-node-secrets-config/pom.xml
+++ b/gravitee-node-secrets/gravitee-node-secrets-config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-secrets</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-secrets-config</artifactId>

--- a/gravitee-node-secrets/gravitee-node-secrets-plugin-handler/pom.xml
+++ b/gravitee-node-secrets/gravitee-node-secrets-plugin-handler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-secrets</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-secrets-plugin-handler</artifactId>

--- a/gravitee-node-secrets/gravitee-secret-provider-mock/pom.xml
+++ b/gravitee-node-secrets/gravitee-secret-provider-mock/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node-secrets</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-secret-provider-mock</artifactId>

--- a/gravitee-node-secrets/pom.xml
+++ b/gravitee-node-secrets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-secrets</artifactId>

--- a/gravitee-node-services/gravitee-node-services-initializer/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-initializer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node.services</groupId>
         <artifactId>gravitee-node-services</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-services-initializer</artifactId>

--- a/gravitee-node-services/gravitee-node-services-upgrader/pom.xml
+++ b/gravitee-node-services/gravitee-node-services-upgrader/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node.services</groupId>
         <artifactId>gravitee-node-services</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-services-upgrader</artifactId>

--- a/gravitee-node-services/pom.xml
+++ b/gravitee-node-services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.node.services</groupId>

--- a/gravitee-node-vertx/pom.xml
+++ b/gravitee-node-vertx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.node</groupId>
         <artifactId>gravitee-node</artifactId>
-        <version>7.0.0-alpha.11</version>
+        <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-node-vertx</artifactId>

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
@@ -24,7 +24,8 @@ public class SslOptions implements Serializable {
     private boolean trustAll;
     private boolean hostnameVerifier = true;
 
-    private boolean openSsl;
+    @Builder.Default
+    private boolean openSsl = false;
 
     @Builder.Default
     private String hostnameVerificationAlgorithm = "NONE";

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientFactory.java
@@ -50,7 +50,17 @@ public class VertxTcpClientFactory {
             .setIdleTimeout(tcpOptions.getIdleTimeout())
             .setIdleTimeoutUnit(TimeUnit.MILLISECONDS)
             .setReadIdleTimeout(tcpOptions.getIdleTimeout())
-            .setWriteIdleTimeout(tcpOptions.getIdleTimeout());
+            .setWriteIdleTimeout(tcpOptions.getWriteIdleTimeout())
+            .setTcpKeepAlive(tcpOptions.isTcpKeepAlive())
+            .setTcpCork(tcpOptions.isTcpCork())
+            .setTcpFastOpen(tcpOptions.isTcpFastOpen())
+            .setTcpNoDelay(tcpOptions.isTcpNoDelay())
+            .setTcpQuickAck(tcpOptions.isTcpQuickAck())
+            .setReuseAddress(tcpOptions.isReuseAddress())
+            .setReusePort(tcpOptions.isReusePort())
+            .setSoLinger(tcpOptions.getSoLinger())
+            .setSendBufferSize(tcpOptions.getSendBufferSize())
+            .setReceiveBufferSize(tcpOptions.getReceiveBufferSize());
 
         configureSsl(clientOptions);
         configureTcpProxy(clientOptions);
@@ -90,7 +100,10 @@ public class VertxTcpClientFactory {
     private void configureSsl(final NetClientOptions clientOptions) {
         clientOptions.setSsl(tcpTarget.isSecured());
         if (sslOptions != null) {
-            sslOptions.setOpenSsl(Boolean.TRUE.equals(nodeConfiguration.getProperty(TCP_SSL_OPENSSL_CONFIGURATION, Boolean.class, false)));
+            // FIXME: we should avoid using APIM property at node level.
+            sslOptions.setOpenSsl(
+                Boolean.TRUE.equals(nodeConfiguration.getProperty(TCP_SSL_OPENSSL_CONFIGURATION, Boolean.class, sslOptions.isOpenSsl()))
+            );
             try {
                 configureSslClientOption(clientOptions, sslOptions);
             } catch (KeyStore.KeyStoreCertOptionsException | TrustStore.TrustOptionsException e) {

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientOptions.java
@@ -1,12 +1,21 @@
 package io.gravitee.node.vertx.client.tcp;
 
+import static io.gravitee.node.vertx.server.VertxServerOptions.DEFAULT_TCP_KEEP_ALIVE;
+import static io.vertx.core.net.TCPSSLOptions.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class VertxTcpClientOptions {
 
     public static final int DEFAULT_IDLE_TIMEOUT = 0;
@@ -16,10 +25,51 @@ public class VertxTcpClientOptions {
     public static final int DEFAULT_RECONNECT_ATTEMPTS = 5;
     public static final int DEFAULT_RECONNECT_INTERVAL = 1000;
 
+    @Builder.Default
     int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+
+    @Builder.Default
     private int reconnectAttempts = DEFAULT_RECONNECT_ATTEMPTS;
+
+    @Builder.Default
     private int reconnectInterval = DEFAULT_RECONNECT_INTERVAL;
+
+    @Builder.Default
     private int idleTimeout = DEFAULT_IDLE_TIMEOUT;
+
+    @Builder.Default
     private int readIdleTimeout = DEFAULT_READ_IDLE_TIMEOUT;
+
+    @Builder.Default
     private int writeIdleTimeout = DEFAULT_WRITE_IDLE_TIMEOUT;
+
+    @Builder.Default
+    private boolean tcpKeepAlive = DEFAULT_TCP_KEEP_ALIVE;
+
+    @Builder.Default
+    private boolean tcpCork = DEFAULT_TCP_CORK;
+
+    @Builder.Default
+    private boolean tcpFastOpen = DEFAULT_TCP_FAST_OPEN;
+
+    @Builder.Default
+    private boolean tcpNoDelay = DEFAULT_TCP_NO_DELAY;
+
+    @Builder.Default
+    private boolean tcpQuickAck = DEFAULT_TCP_QUICKACK;
+
+    @Builder.Default
+    private boolean reuseAddress = DEFAULT_REUSE_ADDRESS;
+
+    @Builder.Default
+    private boolean reusePort = DEFAULT_REUSE_PORT;
+
+    @Builder.Default
+    private int soLinger = DEFAULT_SO_LINGER;
+
+    @Builder.Default
+    private int sendBufferSize = DEFAULT_SEND_BUFFER_SIZE;
+
+    @Builder.Default
+    private int receiveBufferSize = DEFAULT_RECEIVE_BUFFER_SIZE;
 }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpProxyOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpProxyOptions.java
@@ -34,5 +34,6 @@ public class VertxTcpProxyOptions implements Serializable {
 
     private String password;
 
+    @Builder.Default
     private VertxTcpProxyType type = VertxTcpProxyType.SOCKS5;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.node</groupId>
     <artifactId>gravitee-node</artifactId>
-    <version>7.0.0-alpha.11</version>
+    <version>7.0.0-add-more-tcp-options-SNAPSHOT</version>
 
     <name>Gravitee.io - Node</name>
 


### PR DESCRIPTION
**Description**

Add more TCP client options so we can customize them when needed
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.0-add-more-tcp-options-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.0.0-add-more-tcp-options-SNAPSHOT/gravitee-node-7.0.0-add-more-tcp-options-SNAPSHOT.zip)
  <!-- Version placeholder end -->
