### PR TITLE
fix: bump kube client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.31.2</gravitee-reporter-api.version>
-        <gravitee-kubernetes.version>3.5.0</gravitee-kubernetes.version>
+        <gravitee-kubernetes.version>3.5.1</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <hazelcast.version>5.5.0</hazelcast.version>


### PR DESCRIPTION
**Description**

Bump Kube client to 3.5.1

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.4-fix-bump-kube-client-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.0.4-fix-bump-kube-client-SNAPSHOT/gravitee-node-7.0.4-fix-bump-kube-client-SNAPSHOT.zip)
  <!-- Version placeholder end -->
