### PR TITLE
fix: avoid blocking on Hz v5.5 upgrade

### DIFF
--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/spring/HazelcastClusterConfiguration.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/spring/HazelcastClusterConfiguration.java
@@ -21,7 +21,9 @@ import com.hazelcast.config.FileSystemYamlConfig;
 import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.spi.properties.ClusterProperty;
+import com.hazelcast.version.Version;
 import io.gravitee.node.api.Node;
 import java.io.FileNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,18 @@ public class HazelcastClusterConfiguration {
     @Value("${cluster.hazelcast.instance-name:gio-cluster-hz-instance}")
     private String hazelcastInstanceName;
 
+    // WARNING: This option was introduced as a temporary fix for upgrading Hazelcast from v5.3 to v5.5.
+    // Reference: https://github.com/hazelcast/hazelcast/issues/26486
+    //
+    // When enabled ('true'), the Hazelcast cluster name is suffixed with '-hzm<major><minor>'
+    // (e.g., 'graviteeio-apim-cluster-hz55'). This ensures that clusters remain distinct,
+    // preventing an infinite loop where an application embedding Hazelcast v5.5 tries to join a v5.3 cluster.
+    //
+    // The option is enabled by default but can be disabled if running on node >= 6.4.1,
+    // which already includes Hazelcast >= 5.5.
+    @Value("${cluster.hazelcast.cluster-name-versioning:true}")
+    private boolean hazelcastClusterNameVersioning;
+
     @Autowired
     private Node node;
 
@@ -55,6 +69,12 @@ public class HazelcastClusterConfiguration {
         if (!config.getClusterName().contains("cluster")) {
             config.setClusterName(config.getClusterName() + "-cluster-manager");
         }
+
+        if (hazelcastClusterNameVersioning) {
+            Version hzVersion = Version.of(BuildInfoProvider.getBuildInfo().getVersion());
+            config.setClusterName(config.getClusterName() + "-hz" + hzVersion.getMajor() + hzVersion.getMinor());
+        }
+
         config.setProperty(ClusterProperty.HEALTH_MONITORING_LEVEL.getName(), "OFF");
         config.setInstanceName(hazelcastInstanceName);
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-484

**Description**

 This option was introduced as a temporary fix for upgrading Hazelcast from v5.3 to v5.5 (see:  https://github.com/hazelcast/hazelcast/issues/26486)

When enabled, the Hazelcast cluster name is suffixed with `-hzm<major><minor>` (e.g., `graviteeio-apim-cluster-hz55`). This ensures that clusters remain distinct, preventing an infinite loop where an application embedding Hazelcast v5.5 tries to join a v5.3 cluster.

**WARNING**: The option is enabled by default but can be disabled if the application already embeds a version of node >= 6.4.1, which already includes Hazelcast >= 5.5. (cc @mariano-fernandez)

To disable it, specify the following configuration in the gravitee.yaml:

```yaml
cluster:
   hazelcast:
      cluster-name-versioning: false
```

or as an environment variable:

```
gravitee_cluster_hazelcast_clusternameversioning=false
```

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.8-archi-484-fix-hz55-upgrade-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.0.8-archi-484-fix-hz55-upgrade-SNAPSHOT/gravitee-node-7.0.8-archi-484-fix-hz55-upgrade-SNAPSHOT.zip)
  <!-- Version placeholder end -->
