### PR TITLE
fix: allow to configure unknown tier & pack in the license - 5.19.x

### DIFF
--- a/gravitee-node-license/pom.xml
+++ b/gravitee-node-license/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -140,6 +140,63 @@ class DefaultLicenseFactoryTest {
     }
 
     @Test
+    void should_return_license_with_unknown_tier() throws InvalidLicenseException, MalformedLicenseException {
+        final License license = cut.create(
+            REFERENCE_TYPE_PLATFORM,
+            REFERENCE_ID_PLATFORM,
+            generateBase64License("unknown", List.of("enterprise-legacy-upgrade"), null, null)
+        );
+
+        assertThat(license.getTier()).isEqualTo("unknown");
+        assertThat(license.getPacks()).containsExactly("enterprise-legacy-upgrade");
+        assertThat(license.getFeatures()).containsExactlyInAnyOrder("apim-policy-xslt", "apim-policy-ws-security-authentication");
+        assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_PLATFORM);
+        assertThat(license.getReferenceId()).isEqualTo(REFERENCE_ID_PLATFORM);
+    }
+
+    @Test
+    void should_return_license_with_unknown_pack() throws InvalidLicenseException, MalformedLicenseException {
+        final License license = cut.create(
+            REFERENCE_TYPE_PLATFORM,
+            REFERENCE_ID_PLATFORM,
+            generateBase64License("planet", List.of("unknown"), null, null)
+        );
+
+        assertThat(license.getTier()).isEqualTo("planet");
+        assertThat(license.getPacks())
+            .containsExactlyInAnyOrder("enterprise-features", "enterprise-legacy-upgrade", "enterprise-identity-provider", "unknown");
+        assertThat(license.getFeatures())
+            .containsExactlyInAnyOrder(
+                "apim-api-designer",
+                "apim-dcr-registration",
+                "apim-custom-roles",
+                "apim-audit-trail",
+                "apim-sharding-tags",
+                "apim-openid-connect-sso",
+                "apim-debug-mode",
+                "gravitee-risk-assessment",
+                "risk-assessment",
+                "apim-bridge-gateway",
+                "apim-policy-xslt",
+                "apim-policy-ws-security-authentication",
+                "am-idp-salesforce",
+                "am-idp-saml",
+                "am-idp-ldap",
+                "am-idp-kerberos",
+                "am-idp-azure-ad",
+                "am-idp-gateway-handler-saml",
+                "am-gateway-handler-saml-idp",
+                "am-idp-http-flow",
+                "http-flow-am-idp",
+                "am-idp-france-connect",
+                "am-idp-cas",
+                "cas-am-idp"
+            );
+        assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_PLATFORM);
+        assertThat(license.getReferenceId()).isEqualTo(REFERENCE_ID_PLATFORM);
+    }
+
+    @Test
     void should_throw_invalid_license_when_platform_license_is_invalid() {
         assertThrows(InvalidLicenseException.class, () -> cut.create(REFERENCE_TYPE_PLATFORM, REFERENCE_ID_PLATFORM, INVALID_LICENSE));
     }
@@ -397,7 +454,7 @@ class DefaultLicenseFactoryTest {
         license.add(Feature.Create.dateFeature("aDate", new Date(0)));
 
         if (tier != null) {
-            license.add(Feature.Create.stringFeature("tier", "universe"));
+            license.add(Feature.Create.stringFeature("tier", tier));
         }
 
         if (packs != null) {

--- a/gravitee-node-license/src/test/resources/logback-test.xml
+++ b/gravitee-node-license/src/test/resources/logback-test.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="DEBUG" />
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>
+


### PR DESCRIPTION
Applying 8ac83bf5 commit to 5.19.x

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.19.1-fix-unknown-tier-5-19-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/5.19.1-fix-unknown-tier-5-19-x-SNAPSHOT/gravitee-node-5.19.1-fix-unknown-tier-5-19-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
