### PR TITLE
feat: add new log level endpoint

### DIFF
--- a/gravitee-node-management/README.adoc
+++ b/gravitee-node-management/README.adoc
@@ -1,0 +1,135 @@
+= Gravitee Node Management
+
+== Description
+
+The *Gravitee Node Management* module allows exposing a management HTTP server that exposes product information (ex: node info, Prometheus metrics, …).
+It is also extensible as each product can expose its own set of endpoints.
+
+
+== Configuration
+You need to enable the API as a service in the gravitee.yml file and update any other required configuration.
+
+[source,yaml]
+----
+services:
+  core:
+    http:
+      enabled: true
+      port: 18093
+      host: localhost
+      authentication:
+        type: basic
+        users:
+          admin: adminadmin
+----
+
+* enabled: Whether the service is enabled (default true).
+* port: The port the service listens on (default 18093). You must ensure you use a port which is not already in use by another APIM component.
+* host: The host (default localhost).
+* authentication.type: Authentication type for requests: none if no authentication is required or basic (default basic).
+* authentication.users: A list of user: password combinations. Only required if authentication type is basic.
+
+== Technical endpoints
+
+Node exposes different technical endpoints to provide different kind of services or tools.
+
+
+* **Node**
+** **Path:** /_node
+** **Method:** GET
+** **Description:** Gets generic node information
+** **Enabled:** Yes
+
+.Output example
+[source,json]
+----
+{
+  "id" : "652fa0cb-9794-4586-afa0-cb9794558623",
+  "name" : "Gravitee.io - Rest APIs",
+  "metadata" : {
+    "node.id" : "652fa0cb-9794-4586-afa0-cb9794558623",
+    "installation" : "e711c30d-3d6d-4fad-91c3-0d3d6ddfadfa",
+    "node.hostname" : "YourHostname"
+  },
+  "version" : {
+    "BUILD_ID" : "${env.BUILD_ID}",
+    "BUILD_NUMBER" : "${env.BUILD_NUMBER}",
+    "MAJOR_VERSION" : "4.8.0-SNAPSHOT",
+    "REVISION" : "${env.GIT_COMMIT}"
+  },
+  "license" : null
+}
+----
+
+* **Configuration**
+** **Path:** /_node/configuration
+** **Method:** GET
+** **Description:** Get actual node configuration
+** **Enabled:** Yes
+
+.Truncated output example
+[source,json]
+----
+{
+  "analytics.elasticsearch.endpoints[0]" : "http://localhost:9200",
+  "analytics.type" : "elasticsearch",
+  "api.v2.emulateV4Engine.default" : "true",
+  "cluster_type" : "hazelcast",
+  "documentation.audit.max-content-size" : "-1",
+  "documentation.markdown.sanitize" : "true",
+  "documentation.swagger.validate-safe-content" : "true",
+  "ds.elastic.host" : "localhost",
+  "ds.elastic.port" : "9200",
+  "ds.mongodb.dbname" : "gravitee",
+  "ds.mongodb.host" : "localhost",
+  "ds.mongodb.port" : "27017",
+}
+----
+
+* **Logging**
+** **Path:** /_node/logging
+** **Method:** GET/POST
+** **Description:** Check current logging configuration with GET request and dynamically change the logging level of a specific package with POST request. If you want to reset the logger level, just send the same payload with an empty level or null.
+** **Enabled:** Yes
+
+.Payload example (POST request)
+[source,json]
+----
+{"org.springframework.data.mongodb.core.MongoTemplate": "DEBUG"}
+----
+
+.Output example (GET and POST requests)
+[source,json]
+----
+{
+  "org.eclipse.jetty": "INFO",
+  "ROOT": "WARN",
+  "io.gravitee": "INFO",
+  "io.gravitee.rest.api.service.impl.upgrade": "INFO",
+  "org.springframework.data.mongodb.core.MongoTemplate": "DEBUG"
+}
+----
+
+* **Heap Dump**
+** **Path:** /_node/heapdump
+** **Method:** GET
+** **Description:** Dump the heap of the JVM
+** **Enabled:** No
+** **Configuration:** services.core.endpoints.heapdump.enabled
+
+* **Thread Dump**
+** **Path:** /_node/threaddump
+** **Method:** GET
+** **Description:** Dump the threads of the JVM
+** **Enabled:** No
+** **Configuration:** services.core.endpoints.threaddump.enabled
+
+* **Prometheus**
+** **Path:** /_node/metrics/prometheus
+** **Method:** GET
+** **Description:** Expose metrics
+** **Enabled:** No
+** **Configuration:** services.metrics.prometheus.enabled
+
+
+

--- a/gravitee-node-management/pom.xml
+++ b/gravitee-node-management/pom.xml
@@ -54,6 +54,16 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <!-- Logback -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/endpoint/ManagementEndpoint.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/endpoint/ManagementEndpoint.java
@@ -17,14 +17,31 @@ package io.gravitee.node.management.http.endpoint;
 
 import io.gravitee.common.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
+import java.util.List;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface ManagementEndpoint {
+    /**
+     * To use if the endpoint only support one HttpMethod
+     * @return the HttpMethod supported by the endpoint
+     */
     HttpMethod method();
 
+    /**
+     * To use if the endpoint supports multiple HttpMethod (need to manage inside the {@link #handle(RoutingContext context)} implementation)
+     * @return a list of HttpMethod supported by the endpoint
+     */
+    default List<HttpMethod> methods() {
+        return List.of(method());
+    }
+
+    /**
+     * The path of the endpoint
+     * @return a string representation of the endpoint path
+     */
     String path();
 
     void handle(RoutingContext context);

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/node/log/LoggingEndpoint.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/node/log/LoggingEndpoint.java
@@ -1,0 +1,81 @@
+package io.gravitee.node.management.http.node.log;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LoggingEndpoint implements ManagementEndpoint {
+
+    @Override
+    public HttpMethod method() {
+        return null;
+    }
+
+    @Override
+    public List<HttpMethod> methods() {
+        return List.of(HttpMethod.POST, HttpMethod.GET);
+    }
+
+    @Override
+    public String path() {
+        return "/logging";
+    }
+
+    @Override
+    public void handle(RoutingContext context) {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+        // When POST is made, get the body and apply the changes requested
+        if (context.request().method() == io.vertx.core.http.HttpMethod.POST) {
+            //Extract the value from the body
+            context
+                .body()
+                .asJsonObject()
+                .getMap()
+                .forEach((loggerName, level) -> {
+                    if (loggerName != null) {
+                        //If level is empty, set it to null to reset logger to its default
+                        Level newLevel = null;
+                        if (level != null && !level.toString().isEmpty()) {
+                            newLevel = Level.toLevel(level.toString(), null);
+                        }
+                        ch.qos.logback.classic.Logger logger = loggerContext.getLogger(loggerName);
+                        if (logger != null) {
+                            logger.setLevel(newLevel);
+                        }
+                    }
+                });
+        }
+
+        // Return the current configuration
+        HttpServerResponse response = context.response();
+        response.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        Map<String, Object> loggerLevels = new HashMap<>();
+        loggerContext
+            .getLoggerList()
+            .forEach(l -> {
+                if (l.getLevel() != null) {
+                    loggerLevels.put(l.getName(), l.getLevel().toString());
+                }
+            });
+        response.setStatusCode(HttpStatusCode.OK_200);
+        response.end(new JsonObject(loggerLevels).encode());
+    }
+}

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/spring/ManagementConfiguration.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/spring/ManagementConfiguration.java
@@ -17,12 +17,11 @@ package io.gravitee.node.management.http.spring;
 
 import io.gravitee.node.management.http.ManagementService;
 import io.gravitee.node.management.http.configuration.ConfigurationEndpoint;
-import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
 import io.gravitee.node.management.http.metrics.prometheus.PrometheusEndpoint;
 import io.gravitee.node.management.http.node.NodeEndpoint;
 import io.gravitee.node.management.http.node.heap.HeapDumpEndpoint;
+import io.gravitee.node.management.http.node.log.LoggingEndpoint;
 import io.gravitee.node.management.http.node.thread.ThreadDumpEndpoint;
-import io.gravitee.node.management.http.vertx.endpoint.DefaultManagementEndpointManager;
 import io.gravitee.node.management.http.vertx.spring.HttpServerSpringConfiguration;
 import io.gravitee.node.management.http.vertx.verticle.ManagementVerticle;
 import org.springframework.context.annotation.Bean;
@@ -70,5 +69,10 @@ public class ManagementConfiguration {
     @Bean
     public ThreadDumpEndpoint threadDumpEndpoint() {
         return new ThreadDumpEndpoint();
+    }
+
+    @Bean
+    public LoggingEndpoint logUpdateLevelEndpoint() {
+        return new LoggingEndpoint();
     }
 }

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/node/log/LoggingEndpointTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/node/log/LoggingEndpointTest.java
@@ -1,0 +1,134 @@
+package io.gravitee.node.management.http.node.log;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.LoggerContext;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RequestBody;
+import io.vertx.ext.web.RoutingContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LoggingEndpointTest {
+
+    private LoggingEndpoint cut;
+
+    @Mock
+    private RoutingContext routingContext;
+
+    @Mock
+    private HttpServerResponse httpServerResponse;
+
+    @BeforeEach
+    void init() {
+        when(routingContext.response()).thenReturn(httpServerResponse);
+
+        cut = new LoggingEndpoint();
+    }
+
+    @Test
+    void should_return_logger_level() {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        when(routingContext.request()).thenReturn(request);
+
+        Map<String, Object> loggersMap = getCurrentLogger();
+        String expectedOutput = new JsonObject(loggersMap).encode();
+
+        cut.handle(routingContext);
+
+        verify(httpServerResponse).setStatusCode(HttpStatusCode.OK_200);
+        verify(httpServerResponse).end(expectedOutput);
+    }
+
+    @Test
+    void should_change_logger_level() {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(routingContext.request()).thenReturn(request);
+
+        var requestBody = mock(RequestBody.class);
+        Map<String, Object> body = Map.of("io.gravitee.node.management.http.node.log.LoggingEndpointTest", "DEBUG");
+        when(requestBody.asJsonObject()).thenReturn(new JsonObject(body));
+
+        Map<String, Object> loggersMap = getCurrentLogger();
+        loggersMap.put("io.gravitee.node.management.http.node.log.LoggingEndpointTest", "DEBUG");
+        String expectedOutput = new JsonObject(loggersMap).encode();
+
+        when(routingContext.body()).thenReturn(requestBody);
+        cut.handle(routingContext);
+
+        verify(httpServerResponse).setStatusCode(HttpStatusCode.OK_200);
+        verify(httpServerResponse).end(expectedOutput);
+    }
+
+    @Test
+    void should_reset_logger_level_when_level_empty() {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(routingContext.request()).thenReturn(request);
+
+        var requestBody = mock(RequestBody.class);
+        Map<String, Object> body = Map.of("io.gravitee.node.management.http.node.log.AnotherClass", "DEBUG");
+        when(requestBody.asJsonObject()).thenReturn(new JsonObject(body));
+
+        Map<String, Object> loggersMap = getCurrentLogger();
+        String secondOutput = new JsonObject(loggersMap).encode();
+        loggersMap.put("io.gravitee.node.management.http.node.log.AnotherClass", "DEBUG");
+        String firstOutput = new JsonObject(loggersMap).encode();
+
+        when(routingContext.body()).thenReturn(requestBody);
+        cut.handle(routingContext);
+
+        //Send the body again with an empty value for the same logger
+        body = Map.of("io.gravitee.node.management.http.node.log.AnotherClass", "");
+        when(requestBody.asJsonObject()).thenReturn(new JsonObject(body));
+
+        cut.handle(routingContext);
+
+        InOrder inOrder = inOrder(httpServerResponse);
+        inOrder.verify(httpServerResponse).putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        inOrder.verify(httpServerResponse).setStatusCode(HttpStatusCode.OK_200);
+        inOrder.verify(httpServerResponse).end(firstOutput);
+        inOrder.verify(httpServerResponse).putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        inOrder.verify(httpServerResponse).setStatusCode(HttpStatusCode.OK_200);
+        inOrder.verify(httpServerResponse).end(secondOutput);
+    }
+
+    private Map<String, Object> getCurrentLogger() {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        Map<String, Object> loggerLevels = new HashMap<>();
+        loggerContext
+            .getLoggerList()
+            .forEach(l -> {
+                if (l.getLevel() != null) {
+                    loggerLevels.put(l.getName(), l.getLevel().toString());
+                }
+            });
+        return loggerLevels;
+    }
+}

--- a/gravitee-node-management/src/test/resources/logback-test.xml
+++ b/gravitee-node-management/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%date{yyyy-MM-dd HH:mm:ss.SSS} [%-5p] %c: %m%n
+			</Pattern>
+		</layout>
+	</appender>
+
+	<!-- only gravitee Logs in debug -->
+	<logger name="io.gravitee" level="debug" additivity="false">
+		<appender-ref ref="CONSOLE" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root level="warn">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-489

**Description**

This PR aims to add a new technical endpoint that can be used to check the current logging configuration or change the logging level at runtime by specifying a list of package and a level (README has been updated with examples)

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.1.0-feat-add-loglevel-endpoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.1.0-feat-add-loglevel-endpoint-SNAPSHOT/gravitee-node-7.1.0-feat-add-loglevel-endpoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
