### PR TITLE
feat: add new cluster endpoint and cluster health probe

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,6 +49,7 @@ Many enterprise plugins are relying on it.
 
 The Gravitee Node Management module allows exposing a management HTTP server that exposes product information (ex: node info, Prometheus metrics, …).
 It is also extensible as each product can expose its own set of endpoints.
+For more information about this module and the endpoints available, have a look at the module link:gravitee-node-management/README.adoc[README].
 
 === Monitoring
 

--- a/gravitee-node-api/pom.xml
+++ b/gravitee-node-api/pom.xml
@@ -70,5 +70,11 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/ClusterInfo.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/ClusterInfo.java
@@ -1,0 +1,9 @@
+package io.gravitee.node.api.cluster;
+
+import java.util.Set;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record ClusterInfo(String clusterId, boolean running, Member self, Set<Member> members) {}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/ClusterManager.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/ClusterManager.java
@@ -29,6 +29,11 @@ public interface ClusterManager extends Service<ClusterManager> {
      * @return the unique cluster identifier
      */
     String clusterId();
+
+    /**
+     * @return the state of the cluster
+     */
+    boolean isRunning();
     /**
      * @return the current list of members of this cluster
      */
@@ -66,4 +71,8 @@ public interface ClusterManager extends Service<ClusterManager> {
      * @param <T> the type of content that will be published or consumed.
      */
     <T> Queue<T> queue(final String name);
+
+    default ClusterInfo clusterInfo() {
+        return new ClusterInfo(clusterId(), isRunning(), self(), members());
+    }
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/Member.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/cluster/Member.java
@@ -15,22 +15,38 @@
  */
 package io.gravitee.node.api.cluster;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public interface Member {
+    @JsonProperty
     String id();
 
+    @JsonProperty
     boolean primary();
 
+    @JsonProperty
     boolean self();
 
+    @JsonProperty
     String host();
 
+    @JsonProperty
+    String version();
+
+    @JsonProperty
+    Boolean running();
+
+    @JsonProperty
     Map<String, String> attributes();
 
+    @JsonIgnore
     Member attribute(String key, String value);
 }

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/main/java/io/gravitee/node/cluster/NodeClusterService.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/main/java/io/gravitee/node/cluster/NodeClusterService.java
@@ -18,6 +18,8 @@ package io.gravitee.node.cluster;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.cluster.endpoint.ClusterEndpoint;
+import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +39,9 @@ public class NodeClusterService extends AbstractService<NodeClusterService> {
     @Lazy
     private ClusterManager clusterManager;
 
+    @Autowired
+    private ManagementEndpointManager managementEndpointManager;
+
     @Override
     public void doStart() throws Exception {
         super.doStart();
@@ -44,6 +49,7 @@ public class NodeClusterService extends AbstractService<NodeClusterService> {
         node.metadata().put("node.hostname", node.hostname());
         try {
             clusterManager.start();
+            managementEndpointManager.register(new ClusterEndpoint(clusterManager));
         } catch (NoSuchBeanDefinitionException e) {
             log.error("No Cluster manager has been registered.");
             throw new NoClusterManagerException();

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/main/java/io/gravitee/node/cluster/endpoint/ClusterEndpoint.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/main/java/io/gravitee/node/cluster/endpoint/ClusterEndpoint.java
@@ -1,0 +1,51 @@
+package io.gravitee.node.cluster.endpoint;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ClusterEndpoint implements ManagementEndpoint {
+
+    private final ClusterManager clusterManager;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/cluster";
+    }
+
+    @Override
+    public void handle(RoutingContext context) {
+        var response = context.response();
+
+        try {
+            response.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+            response.setChunked(true);
+            response.setStatusCode(HttpStatusCode.OK_200);
+            response.write(objectMapper.writeValueAsString(clusterManager.clusterInfo()));
+        } catch (JsonProcessingException jsonProcessingException) {
+            log.error("An error occurred while handling the cluster info", jsonProcessingException);
+            response.setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
+        }
+        response.end();
+    }
+}

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/main/java/io/gravitee/node/cluster/healthcheck/ClusterProbe.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/main/java/io/gravitee/node/cluster/healthcheck/ClusterProbe.java
@@ -1,0 +1,41 @@
+package io.gravitee.node.cluster.healthcheck;
+
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.healthcheck.Probe;
+import io.gravitee.node.api.healthcheck.Result;
+import io.vertx.core.Promise;
+import java.util.concurrent.CompletionStage;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+public class ClusterProbe implements Probe {
+
+    @Autowired
+    private ClusterManager clusterManager;
+
+    @Override
+    public String id() {
+        return "cluster";
+    }
+
+    @Override
+    public CompletionStage<Result> check() {
+        Promise<Result> promise = Promise.promise();
+
+        if (clusterManager.isRunning() && clusterManager.self().running()) {
+            promise.complete(Result.healthy());
+        } else {
+            promise.complete(Result.unhealthy("Cluster is not running"));
+        }
+
+        return promise.future().toCompletionStage();
+    }
+}

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/main/resources/META-INF/spring.factories
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,4 @@
 io.gravitee.plugin.core.api.PluginHandler=\
 io.gravitee.node.cluster.plugin.ClusterPluginHandler
+io.gravitee.node.api.healthcheck.Probe=\
+    io.gravitee.node.cluster.healthcheck.ClusterProbe

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/test/java/io/gravitee/node/cluster/endpoint/ClusterEndpointTest.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/test/java/io/gravitee/node/cluster/endpoint/ClusterEndpointTest.java
@@ -1,0 +1,110 @@
+package io.gravitee.node.cluster.endpoint;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.node.api.cluster.ClusterInfo;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import java.util.Map;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClusterEndpointTest {
+
+    private ClusterEndpoint cut;
+
+    @Mock
+    private ClusterManager clusterManager;
+
+    @Mock
+    private RoutingContext routingContext;
+
+    @Mock
+    private HttpServerResponse response;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        when(routingContext.response()).thenReturn(response);
+
+        cut = new ClusterEndpoint(clusterManager);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_cluster_info() {
+        var member = new TestMember();
+        var clusterInfo = new ClusterInfo("clusterId", true, member, Set.of(member));
+        when(clusterManager.clusterInfo()).thenReturn(clusterInfo);
+        String expectedOutput = objectMapper.writeValueAsString(clusterInfo);
+
+        cut.handle(routingContext);
+
+        verify(response).setStatusCode(200);
+        verify(response).putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        verify(response).write(expectedOutput);
+    }
+
+    private static class TestMember implements Member {
+
+        @Override
+        public String id() {
+            return "testMemberId";
+        }
+
+        @Override
+        public boolean primary() {
+            return true;
+        }
+
+        @Override
+        public boolean self() {
+            return true;
+        }
+
+        @Override
+        public String host() {
+            return "host";
+        }
+
+        @Override
+        public String version() {
+            return "1.4.5";
+        }
+
+        @Override
+        public Boolean running() {
+            return true;
+        }
+
+        @Override
+        public Map<String, String> attributes() {
+            return Map.of();
+        }
+
+        @Override
+        public Member attribute(String key, String value) {
+            return this;
+        }
+    }
+}

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/test/java/io/gravitee/node/cluster/healthcheck/ClusterProbeTest.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-handler/src/test/java/io/gravitee/node/cluster/healthcheck/ClusterProbeTest.java
@@ -1,0 +1,60 @@
+package io.gravitee.node.cluster.healthcheck;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
+import java.util.concurrent.ExecutionException;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClusterProbeTest {
+
+    private ClusterProbe cut;
+
+    @Mock
+    private ClusterManager clusterManager;
+
+    @BeforeEach
+    void setUp() {
+        cut = new ClusterProbe(clusterManager);
+    }
+
+    @Test
+    @SneakyThrows
+    public void should_be_healthy_when_cluster_is_running() {
+        when(clusterManager.isRunning()).thenReturn(true);
+        Member member = mock(Member.class);
+        when(member.running()).thenReturn(true);
+        when(clusterManager.self()).thenReturn(member);
+
+        var result = cut.check().toCompletableFuture().get();
+
+        assertThat(result.isHealthy()).isTrue();
+    }
+
+    @Test
+    @SneakyThrows
+    public void should_be_unhealthy_when_cluster_is_not_running() {
+        when(clusterManager.isRunning()).thenReturn(false);
+
+        var result = cut.check().toCompletableFuture().get();
+
+        assertThat(result.isHealthy()).isFalse();
+    }
+}

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastClusterManager.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastClusterManager.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.node.plugin.cluster.hazelcast;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.MembershipEvent;
 import com.hazelcast.cluster.MembershipListener;
 import com.hazelcast.collection.IQueue;
@@ -69,19 +70,24 @@ public class HazelcastClusterManager extends AbstractService<ClusterManager> imp
     }
 
     @Override
+    public boolean isRunning() {
+        return hazelcastInstance.getCluster().getClusterState() == ClusterState.ACTIVE;
+    }
+
+    @Override
     public Set<Member> members() {
         return hazelcastInstance
             .getCluster()
             .getMembers()
             .stream()
-            .map(member -> new HazelcastMember(member, isPrimaryMember(member)))
+            .map(member -> new HazelcastMember(member, isPrimaryMember(member), true))
             .collect(Collectors.toSet());
     }
 
     @Override
     public Member self() {
         com.hazelcast.cluster.Member localMember = hazelcastInstance.getCluster().getLocalMember();
-        return new HazelcastMember(localMember, isPrimaryMember(localMember));
+        return new HazelcastMember(localMember, isPrimaryMember(localMember), hazelcastInstance.getLifecycleService().isRunning());
     }
 
     @Override

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastMember.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-hazelcast/src/main/java/io/gravitee/node/plugin/cluster/hazelcast/HazelcastMember.java
@@ -17,17 +17,20 @@ package io.gravitee.node.plugin.cluster.hazelcast;
 
 import io.gravitee.node.api.cluster.Member;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@AllArgsConstructor
 @RequiredArgsConstructor
 public class HazelcastMember implements Member {
 
     private final com.hazelcast.cluster.Member member;
     private final boolean primary;
+    private Boolean running;
 
     @Override
     public String id() {
@@ -47,6 +50,16 @@ public class HazelcastMember implements Member {
     @Override
     public String host() {
         return member.getAddress().getHost();
+    }
+
+    @Override
+    public String version() {
+        return member.getVersion().toString();
+    }
+
+    @Override
+    public Boolean running() {
+        return running;
     }
 
     @Override

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/StandaloneClusterManager.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/StandaloneClusterManager.java
@@ -54,6 +54,11 @@ public class StandaloneClusterManager extends AbstractService<ClusterManager> im
     }
 
     @Override
+    public boolean isRunning() {
+        return true;
+    }
+
+    @Override
     public Set<Member> members() {
         return Set.of(LOCAL_MEMBER);
     }

--- a/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/StandaloneMember.java
+++ b/gravitee-node-cluster/gravitee-node-cluster-plugin-standalone/src/main/java/io/gravitee/node/plugin/cluster/standalone/StandaloneMember.java
@@ -50,6 +50,16 @@ public class StandaloneMember implements Member {
     }
 
     @Override
+    public String version() {
+        return "standalone";
+    }
+
+    @Override
+    public Boolean running() {
+        return true;
+    }
+
+    @Override
     public Map<String, String> attributes() {
         return attributes;
     }

--- a/gravitee-node-management/README.adoc
+++ b/gravitee-node-management/README.adoc
@@ -110,6 +110,46 @@ Node exposes different technical endpoints to provide different kind of services
 }
 ----
 
+* **Cluster**
+** **Path:** /_node/cluster
+** **Method:** GET
+** **Description:** Get the current state of the cluster with information about members
+** **Enabled:** Yes
+
+.Output example (using Hazelcast implementation)
+[source,json]
+----
+{
+  "clusterId": "gio-apim-gateway-cluster-manager-hz55",
+  "running": true, #state of the cluster
+  "self": {
+    "primary": true,
+    "running": true, #state of the current member
+    "attributes": {
+      "gio_node_hostname": "node_hostname",
+      "gio_node_id": "node_id"
+    },
+    "version": "5.5.0",
+    "host": "127.0.0.1",
+    "id": "member_id",
+    "self": true
+  },
+  "members": [
+    {
+      "primary": true,
+      "attributes": {
+        "gio_node_hostname": "node_hostname",
+        "gio_node_id": "node_id"
+      },
+      "version": "5.5.0",
+      "host": "127.0.0.1",
+      "id": "member_id",
+      "self": true
+    }
+  ]
+}
+----
+
 * **Heap Dump**
 ** **Path:** /_node/heapdump
 ** **Method:** GET


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-488

**Description**

This PR adds a new technical endpoint to get information on the cluster running. The idea is to provide data that could help when we need to check the version or the members connected etc. The implementation is generic and each cluster provider need to implement some method to set the data used by the endpoint. A new probe has also been added that allows to check the health of the cluster. For the Hazelcast implementation, the probe uses the cluster state and the node state.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.2.0-feat-add-cluster-endpoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.2.0-feat-add-cluster-endpoint-SNAPSHOT/gravitee-node-7.2.0-feat-add-cluster-endpoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
