### PR TITLE
fix: added traceparent getter in opentelemetry span

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Span.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Span.java
@@ -26,6 +26,11 @@ public interface Span {
     boolean isRoot();
 
     /**
+     * @return traceparent value.
+     */
+    String getTraceparent();
+
+    /**
      * Append custom attribute to the span while it is already created.
      *
      * @return current {@link Span}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/noop/NoOpSpan.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/noop/NoOpSpan.java
@@ -42,6 +42,11 @@ public class NoOpSpan implements Span {
     }
 
     @Override
+    public String getTraceparent() {
+        return "";
+    }
+
+    @Override
     public <T> Span withAttribute(final String name, final T value) {
         return this;
     }

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/span/OpenTelemetrySpan.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/span/OpenTelemetrySpan.java
@@ -16,6 +16,7 @@
 package io.gravitee.node.opentelemetry.tracer.span;
 
 import io.gravitee.node.api.opentelemetry.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Scope;
 import lombok.Getter;
 import lombok.experimental.Accessors;
@@ -61,6 +62,12 @@ public class OpenTelemetrySpan<R> implements Span {
     @Override
     public boolean isRoot() {
         return root;
+    }
+
+    @Override
+    public String getTraceparent() {
+        SpanContext spanContext = span().getSpanContext();
+        return "00-" + spanContext.getTraceId() + "-" + spanContext.getSpanId() + "-" + spanContext.getTraceFlags().asHex();
     }
 
     @Override


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/10511

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.1.1-APIM-9423-traceparent-otel-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.1.1-APIM-9423-traceparent-otel-SNAPSHOT/gravitee-node-7.1.1-APIM-9423-traceparent-otel-SNAPSHOT.zip)
  <!-- Version placeholder end -->
