### PR TITLE
feat(license): add support for kafka-policy-transform-key in license yml

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -105,6 +105,7 @@ packs:
             - apim-native-kafka-policy-quota
             - apim-native-kafka-policy-topic-mapping
             - apim-native-kafka-policy-offloading
+            - apim-native-kafka-policy-transform-key
 
 tiers:
     planet:


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8989

**Description**

Add support for kafka-policy-transform-key in license yml

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.4.0-APIM-8989-add-new-kafka-policy-in-license-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.4.0-APIM-8989-add-new-kafka-policy-in-license-SNAPSHOT/gravitee-node-7.4.0-APIM-8989-add-new-kafka-policy-in-license-SNAPSHOT.zip)
  <!-- Version placeholder end -->
