### PR TITLE
fix: update reporter-api to 1.32.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <gravitee-bom.version>8.2.9</gravitee-bom.version>
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
-        <gravitee-reporter-api.version>1.31.2</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.32.3</gravitee-reporter-api.version>
         <gravitee-kubernetes.version>3.5.1</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.4.1-update-reporter-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.4.1-update-reporter-api-SNAPSHOT/gravitee-node-7.4.1-update-reporter-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
