### PR TITLE
fix: avoid duplicate probes and concurrent evaluations

### DIFF
--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/ProbeManagerImplTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/ProbeManagerImplTest.java
@@ -1,0 +1,54 @@
+package io.gravitee.node.monitoring.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+import io.gravitee.node.api.healthcheck.Probe;
+import io.gravitee.node.monitoring.healthcheck.probe.CPUProbe;
+import io.gravitee.node.monitoring.healthcheck.probe.MemoryProbe;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class ProbeManagerImplTest {
+
+    @Mock
+    private Probe probe;
+
+    private ProbeManagerImpl cut;
+
+    @BeforeEach
+    void beforeEach() {
+        cut = new ProbeManagerImpl();
+        cut.setApplicationContext(new AnnotationConfigApplicationContext());
+        lenient().when(probe.id()).thenReturn("probeId");
+    }
+
+    @Test
+    void should_discover_and_register_cpu_and_memory_probes() {
+        final List<Probe> probes = cut.getProbes();
+        assertThat(probes).hasSize(2).hasOnlyElementsOfTypes(CPUProbe.class, MemoryProbe.class);
+    }
+
+    @Test
+    void should_register_probe() {
+        cut.register(probe);
+        assertThat(cut.getProbes()).contains(probe);
+    }
+
+    @Test
+    void should_not_register_cpu_probe_twice() {
+        CPUProbe cpuProbe = new CPUProbe();
+        cut.register(cpuProbe);
+        assertThat(cut.getProbes()).hasSize(2).contains(cpuProbe);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-504

**Description**

This PR makes sure that the same probe isn't registered twice (via Spring and manually). It also ensures that there is only 1 evaluation of probes at a time to avoid putting too much pressure.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.4.2-archi-504-avoid-probe-duplicate-evaluations-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.4.2-archi-504-avoid-probe-duplicate-evaluations-SNAPSHOT/gravitee-node-7.4.2-archi-504-avoid-probe-duplicate-evaluations-SNAPSHOT.zip)
  <!-- Version placeholder end -->
