### PR TITLE
Revert "feat: add new "ai-gateway" pack"

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -106,10 +106,6 @@ packs:
             - apim-native-kafka-policy-topic-mapping
             - apim-native-kafka-policy-offloading
             - apim-native-kafka-policy-transform-key
-    ai-gateway:
-        features:
-            - ai-gateway-policy-guard-rails
-            - ai-gateway-policy-token-tracking
 
 tiers:
     planet:


### PR DESCRIPTION
Reverts gravitee-io/gravitee-node#418

From Product, slight change of direction in terms of the availability of the two new AI gateway policies.
We want to make these policies open source and available to all users by default.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.5.1-revert-418-apim9299-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.5.1-revert-418-apim9299-SNAPSHOT/gravitee-node-7.5.1-revert-418-apim9299-SNAPSHOT.zip)
  <!-- Version placeholder end -->
