### PR TITLE
feat: add agent-proxy entrypoint and endpoint in event native features

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -78,11 +78,13 @@ packs:
             - apim-en-entrypoint-websocket
             - apim-en-entrypoint-http-post
             - apim-en-entrypoint-sse
+            - apim-en-entrypoint-agent-proxy
             - apim-en-endpoint-mqtt5
             - apim-en-endpoint-rabbitmq
             - apim-en-endpoint-kafka
             - apim-en-endpoint-solace
             - apim-en-endpoint-asb
+            - apim-en-endpoint-agent-proxy
             - apim-en-schema-registry-provider
             - apim-connectors-advanced # for removal
     enterprise-secret-manager:

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -109,7 +109,9 @@ class DefaultLicenseFactoryTest {
                 "apim-en-endpoint-mqtt5",
                 "apim-en-entrypoint-http-post",
                 "apim-en-endpoint-kafka",
-                "apim-en-endpoint-asb"
+                "apim-en-endpoint-asb",
+                "apim-en-entrypoint-agent-proxy",
+                "apim-en-endpoint-agent-proxy"
             );
         assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_PLATFORM);
         assertThat(license.getReferenceId()).isEqualTo(REFERENCE_ID_PLATFORM);
@@ -406,6 +408,8 @@ class DefaultLicenseFactoryTest {
             "apim-policy-interops-r-sp",
             "apim-policy-oas-validation",
             "apim-policy-data-cache",
+            "apim-en-entrypoint-agent-proxy",
+            "apim-en-endpoint-agent-proxy",
         };
         assertThat(license.getFeatures()).containsExactlyInAnyOrder(features);
 


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-9561

**Description**

Add agent proxy entries in the license

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.7.0-apim-9561-agent-proxy-feature-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.7.0-apim-9561-agent-proxy-feature-SNAPSHOT/gravitee-node-7.7.0-apim-9561-agent-proxy-feature-SNAPSHOT.zip)
  <!-- Version placeholder end -->
