### PR TITLE
Improve exception handling in upgrader logs

### DIFF
--- a/gravitee-node-api/README.adoc
+++ b/gravitee-node-api/README.adoc
@@ -1,0 +1,33 @@
+= Gravitee-io - Node API
+
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License",link="https://github.com/gravitee-io/graviteeio-node/blob/master/LICENSE.txt"]
+image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases",link="https://github.com/gravitee-io/graviteeio-node/releases"]
+image:https://circleci.com/gh/gravitee-io/gravitee-node.svg?style=svg["CircleCI",link="https://circleci.com/gh/gravitee-io/gravitee-node"]
+image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum",link="https://community.gravitee.io?utm_source=readme", height=20]
+
+== Description
+
+The Gravitee Node API module regroups all the interfaces that are implemented in the other modules.
+
+== Packages
+
+=== Upgrader
+To create a new Upgrader, you need to implement the `Upgrader` interface in your project.
+When implementing the `upgrade` method, it’s recommended to use the `wrapException` method provided by the interface.
+This will ensure that any exception is wrapped into an `UpgraderException`.
+
+*Do not catch the exceptions yourself!* They will be handled by the caller.
+
+1. Move your business logic into a private method.
+2. In the `upgrade` method, call `wrapException` from the `Upgrader` interface.
+3. Pass your private method as a parameter to `wrapException`.
+
+[source,java]
+----
+import io.gravitee.node.api.upgrader.UpgraderException;
+
+@Override
+public boolean upgrade() throws UpgraderException {
+    return this.wrapException(this::myBusinessLogic);
+}
+----

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/UpgradeStatus.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/UpgradeStatus.java
@@ -1,0 +1,7 @@
+package io.gravitee.node.api.upgrader;
+
+public enum UpgradeStatus {
+    SUCCESS,
+    FAILED,
+    FAILED_WITH_EXCEPTION,
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/Upgrader.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/Upgrader.java
@@ -21,7 +21,19 @@ package io.gravitee.node.api.upgrader;
  * @author GraviteeSource Team
  */
 public interface Upgrader {
-    boolean upgrade();
+    /**
+     * Executes the upgrade logic for this component.
+     * <p>
+     * This method is called during the node startup process. It should return {@code true}
+     * if the upgrade was successfully applied, or {@code false} if the upgrade is not applicable
+     * (e.g., already applied or due to a business condition).
+     * <p>
+     * Implementations should wrap their logic using {@link #wrapException(ThrowingSupplier)}
+     * to ensure consistent exception handling and avoid silent failures.
+     * @return true if the upgrade has been successfully applied, false otherwise.
+     * @throws UpgraderException if the upgrade failed because of an exception.
+     */
+    boolean upgrade() throws UpgraderException;
 
     int getOrder();
 
@@ -35,5 +47,30 @@ public interface Upgrader {
             return className + "_" + version();
         }
         return className;
+    }
+
+    /**
+     * Wraps the execution of a supplier that may throw an exception, and converts any thrown exception
+     * into an {@link UpgraderException}. This method is intended to standardize error handling within
+     * upgrade logic.
+     * <p>
+     * If the supplier returns {@code null}, the method will return {@code false}.
+     *
+     * @param supplier the logic to execute, typically containing the business code of the upgrade
+     * @return {@code true} if the supplier returned {@code true}, {@code false} otherwise (including null/void)
+     * @throws UpgraderException if the supplier throws any exception during execution
+     */
+    default boolean wrapException(ThrowingSupplier<Boolean> supplier) throws UpgraderException {
+        try {
+            Boolean result = supplier.get();
+            return result != null && result;
+        } catch (Exception e) {
+            throw new UpgraderException(e);
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingSupplier<T> {
+        T get() throws Exception;
     }
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/UpgraderException.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/upgrader/UpgraderException.java
@@ -1,0 +1,8 @@
+package io.gravitee.node.api.upgrader;
+
+public class UpgraderException extends Exception {
+
+    public UpgraderException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9632

**Description**

This PR modifies the handling of exceptions in the upgrader's `upgrade` method. Exceptions are now thrown and managed by the caller (`upgradeServiceImpl`) instead of being handled within the upgrader itself. A new `wrapException` method has been introduced to ensure consistent exception wrapping.

**Additional context**

Originally the issue came from this ticket: https://gravitee.atlassian.net/browse/APIM-9518.
After a quick fix https://github.com/gravitee-io/gravitee-api-management/pull/11783, we thought it could be a good idea to avoid nested try-catch blocks and hidden Exception. Also, we want to add a way to centralize the exception handling.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.7.0-apim-9632-improve-error-handling-trycatch-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.7.0-apim-9632-improve-error-handling-trycatch-SNAPSHOT/gravitee-node-7.7.0-apim-9632-improve-error-handling-trycatch-SNAPSHOT.zip)
  <!-- Version placeholder end -->
