### PR TITLE
fix: rename agent-proxy license entry to fit with the protocol name

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -78,13 +78,13 @@ packs:
             - apim-en-entrypoint-websocket
             - apim-en-entrypoint-http-post
             - apim-en-entrypoint-sse
-            - apim-en-entrypoint-agent-proxy
+            - apim-en-entrypoint-agent-to-agent
             - apim-en-endpoint-mqtt5
             - apim-en-endpoint-rabbitmq
             - apim-en-endpoint-kafka
             - apim-en-endpoint-solace
             - apim-en-endpoint-asb
-            - apim-en-endpoint-agent-proxy
+            - apim-en-endpoint-agent-to-agent
             - apim-en-schema-registry-provider
             - apim-connectors-advanced # for removal
     enterprise-secret-manager:

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -110,8 +110,8 @@ class DefaultLicenseFactoryTest {
                 "apim-en-entrypoint-http-post",
                 "apim-en-endpoint-kafka",
                 "apim-en-endpoint-asb",
-                "apim-en-entrypoint-agent-proxy",
-                "apim-en-endpoint-agent-proxy"
+                "apim-en-entrypoint-agent-to-agent",
+                "apim-en-endpoint-agent-to-agent"
             );
         assertThat(license.getReferenceType()).isEqualTo(REFERENCE_TYPE_PLATFORM);
         assertThat(license.getReferenceId()).isEqualTo(REFERENCE_ID_PLATFORM);
@@ -408,8 +408,8 @@ class DefaultLicenseFactoryTest {
             "apim-policy-interops-r-sp",
             "apim-policy-oas-validation",
             "apim-policy-data-cache",
-            "apim-en-entrypoint-agent-proxy",
-            "apim-en-endpoint-agent-proxy",
+            "apim-en-entrypoint-agent-to-agent",
+            "apim-en-endpoint-agent-to-agent",
         };
         assertThat(license.getFeatures()).containsExactlyInAnyOrder(features);
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9563

**Description**

 rename agent-proxy license entry to fit with the protocol name

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.7.1-apim-9563-agent-to-agent-feature-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.7.1-apim-9563-agent-to-agent-feature-SNAPSHOT/gravitee-node-7.7.1-apim-9563-agent-to-agent-feature-SNAPSHOT.zip)
  <!-- Version placeholder end -->
