### PR TITLE
fix: Prometheus OOM error

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpoint.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpoint.java
@@ -20,11 +20,13 @@ import static io.vertx.core.http.HttpHeaders.*;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.gravitee.node.management.http.utils.SafeBufferedWriter;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.micrometer.backends.BackendRegistries;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
 import org.slf4j.Logger;
@@ -56,66 +58,11 @@ public class PrometheusEndpoint implements ManagementEndpoint {
         response.putHeader(CONTENT_TYPE, CONTENT_TYPE_004);
         response.setChunked(true);
 
-        try (BufferWriter writer = new BufferWriter(response)) {
+        try (BufferedWriter writer = new BufferedWriter(new SafeBufferedWriter(response))) {
             registry.scrape(writer);
         } catch (IOException ioe) {
             LOGGER.error("Unexpected error while scraping the Prometheus endpoint", ioe);
             response.close();
         }
-    }
-
-    private static class BufferWriter extends Writer {
-
-        private final HttpServerResponse response;
-
-        private BufferWriter(HttpServerResponse response) {
-            this.response = response;
-        }
-
-        @Override
-        public void write(char[] cbuf, int off, int len) throws IOException {
-            push(Buffer.buffer(charArrayToByteArray(cbuf)));
-        }
-
-        @Override
-        public void write(int c) throws IOException {
-            push(Buffer.buffer(1).appendByte((byte) (c & 0xFF)));
-        }
-
-        @Override
-        public void write(char[] cbuf) throws IOException {
-            push(Buffer.buffer(new String(cbuf)));
-        }
-
-        @Override
-        public void write(String str) throws IOException {
-            push(Buffer.buffer(str));
-        }
-
-        @Override
-        public void write(String str, int off, int len) throws IOException {
-            push(Buffer.buffer(str));
-        }
-
-        private void push(Buffer buffer) {
-            response.write(buffer);
-        }
-
-        @Override
-        public void flush() {}
-
-        @Override
-        public void close() throws IOException {
-            response.end();
-        }
-    }
-
-    private static byte[] charArrayToByteArray(char[] charBuf) {
-        if (charBuf == null) return null;
-        int iLen = charBuf.length;
-        byte[] buf = new byte[iLen];
-        for (int p = 0; p < iLen; p++) buf[p] = (byte) (charBuf[p]);
-
-        return buf;
     }
 }

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandler.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandler.java
@@ -1,0 +1,53 @@
+package io.gravitee.node.management.http.utils;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static io.prometheus.client.exporter.common.TextFormat.CONTENT_TYPE_004;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import java.util.concurrent.Semaphore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConcurrencyLimitHandler implements Handler<RoutingContext> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrencyLimitHandler.class);
+    private static final int TOO_MANY_REQUESTS = 429;
+
+    private final Semaphore semaphore;
+    private final int maxConcurrentRequests;
+
+    public ConcurrencyLimitHandler(int maxConcurrentRequests) {
+        this.maxConcurrentRequests = maxConcurrentRequests;
+        this.semaphore = new Semaphore(maxConcurrentRequests);
+    }
+
+    @Override
+    public void handle(RoutingContext context) {
+        if (!semaphore.tryAcquire()) {
+            LOGGER.warn(
+                "The endpoint rejected request due to concurrency limit of {} for path {} ",
+                maxConcurrentRequests,
+                context.request().path()
+            );
+            context
+                .response()
+                .setStatusCode(TOO_MANY_REQUESTS)
+                .putHeader(CONTENT_TYPE, CONTENT_TYPE_004)
+                .end("Too Many Requests - limit of " + maxConcurrentRequests + " for path " + context.request().path());
+            return;
+        }
+
+        HttpServerResponse response = context.response();
+
+        // Release semaphore when request ends or fails
+        response.bodyEndHandler(v -> semaphore.release());
+        response.exceptionHandler(e -> {
+            LOGGER.error("Error thrown  ", e);
+            semaphore.release();
+        });
+
+        context.next();
+    }
+}

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/OffloadHandler.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/OffloadHandler.java
@@ -1,0 +1,53 @@
+package io.gravitee.node.management.http.utils;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.ext.web.RoutingContext;
+
+public class OffloadHandler {
+
+    /**
+     * Wraps a blocking operation inside Vert.x's executeBlocking.
+     *
+     * @param blockingHandler the handler that performs blocking code and resolves the promise
+     * @return a routing handler that offloads blocking logic to a worker thread
+     */
+    public static Handler<RoutingContext> of(Handler<Promise<Void>> blockingHandler) {
+        return ctx -> {
+            ctx
+                .vertx()
+                .executeBlocking(blockingHandler)
+                .onSuccess(v -> {
+                    // Do nothing — assume the handler already finished response writing
+                })
+                .onFailure(t -> {
+                    ctx.response().setStatusCode(500).end("Internal server error");
+                });
+        };
+    }
+
+    /**
+     * Wraps a RoutingContext-aware blocking handler.
+     *
+     * @param blockingHandler the blocking logic that accepts RoutingContext and resolves the promise
+     * @return a routing handler that offloads the logic
+     */
+    public static Handler<RoutingContext> ofCtx(BiHandler<RoutingContext, Promise<Void>> blockingHandler) {
+        return ctx -> {
+            ctx
+                .vertx()
+                .executeBlocking(promise -> blockingHandler.handle(ctx, promise))
+                .onSuccess(v -> {
+                    // Do nothing
+                })
+                .onFailure(t -> {
+                    ctx.response().setStatusCode(500).end("Internal server error");
+                });
+        };
+    }
+
+    @FunctionalInterface
+    public interface BiHandler<T, U> {
+        void handle(RoutingContext t, Promise<Object> u);
+    }
+}

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/SafeBufferedWriter.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/SafeBufferedWriter.java
@@ -1,0 +1,62 @@
+package io.gravitee.node.management.http.utils;
+
+import io.vertx.core.http.HttpServerResponse;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class SafeBufferedWriter extends Writer {
+
+    private static final int DRAIN_TIMEOUT_MS = 5000;
+
+    private final HttpServerResponse response;
+
+    public SafeBufferedWriter(HttpServerResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        String data = new String(cbuf, off, len);
+        writeWithBackpressure(data);
+    }
+
+    @Override
+    public void write(int c) throws IOException {
+        writeWithBackpressure(Character.toString((char) c));
+    }
+
+    @Override
+    public void write(String str) throws IOException {
+        writeWithBackpressure(str);
+    }
+
+    private void writeWithBackpressure(String data) throws IOException {
+        if (response.writeQueueFull()) {
+            CountDownLatch latch = new CountDownLatch(1);
+            response.drainHandler(v -> latch.countDown());
+
+            try {
+                if (!latch.await(DRAIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    throw new IOException("Timeout while waiting for write queue to drain");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while waiting for write queue to drain", e);
+            }
+        }
+
+        response.write(data);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        // No-op — Vert.x handles flushing internally
+    }
+
+    @Override
+    public void close() throws IOException {
+        // No-op — caller is responsible for closing the response
+    }
+}

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandlerTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandlerTest.java
@@ -1,0 +1,50 @@
+package io.gravitee.node.management.http.utils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConcurrencyLimitHandlerTest {
+
+    private RoutingContext mockContext;
+    private HttpServerResponse mockResponse;
+    private HttpServerRequest mockRequest;
+
+    @BeforeEach
+    void setup() {
+        mockContext = mock(RoutingContext.class);
+        mockRequest = mock(HttpServerRequest.class);
+        mockResponse = mock(HttpServerResponse.class);
+        when(mockContext.request()).thenReturn(mockRequest);
+        when(mockRequest.path()).thenReturn("/test");
+        when(mockContext.response()).thenReturn(mockResponse);
+        when(mockResponse.setStatusCode(anyInt())).thenReturn(mockResponse);
+        when(mockResponse.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(mockResponse);
+        when(mockResponse.endHandler(any())).thenReturn(mockResponse);
+    }
+
+    @Test
+    void should_reject_request_when_limit_reached() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(0);
+        when(mockResponse.putHeader(anyString(), anyString())).thenReturn(mockResponse);
+        handler.handle(mockContext);
+        verify(mockResponse).setStatusCode(429);
+        verify(mockResponse).end("Too Many Requests - limit of 0 for path /test");
+        verify(mockContext, never()).next();
+    }
+
+    @Test
+    void should_allow_request_when_slot_available() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+        verify(mockContext).next();
+        verify(mockResponse).bodyEndHandler(any());
+        verify(mockResponse, never()).setStatusCode(429);
+    }
+}

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/OffloadHandlerTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/OffloadHandlerTest.java
@@ -1,0 +1,97 @@
+package io.gravitee.node.management.http.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+public class OffloadHandlerTest {
+
+    @Mock
+    Vertx vertx;
+
+    @Mock
+    RoutingContext routingContext;
+
+    @Mock
+    HttpServerResponse response;
+
+    @Captor
+    ArgumentCaptor<Handler<Promise<Void>>> handlerCaptor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(routingContext.vertx()).thenReturn(vertx);
+        when(routingContext.response()).thenReturn(response);
+        when(response.setStatusCode(anyInt())).thenReturn(response);
+    }
+
+    @Test
+    void should_execute_blocking_handler_successfully() {
+        Promise<Void> promise = Promise.promise();
+
+        when(vertx.<Void>executeBlocking(handlerCaptor.capture())).thenReturn(Future.succeededFuture());
+
+        var handler = OffloadHandler.ofCtx((ctx, p) -> {
+            assertEquals(routingContext, ctx);
+            p.complete();
+        });
+
+        handler.handle(routingContext);
+        Handler<Promise<Void>> captured = handlerCaptor.getValue();
+        captured.handle(promise);
+        assertTrue(promise.future().succeeded());
+    }
+
+    @Test
+    void should_execute_blocking_handler_with_failure() {
+        when(vertx.<Void>executeBlocking(any(Handler.class))).thenReturn(Future.failedFuture(new RuntimeException("fail")));
+
+        var handler = OffloadHandler.ofCtx((ctx, p) -> {});
+
+        handler.handle(routingContext);
+
+        verify(response).setStatusCode(500);
+        verify(response).end("Internal server error");
+    }
+
+    @Test
+    void should_execute_simple_blocking_handler_successfully() {
+        Handler<Promise<Void>> blockingHandler = promise -> promise.complete();
+
+        when(vertx.<Void>executeBlocking(ArgumentMatchers.<Handler<Promise<Void>>>any()))
+            .thenAnswer(invocation -> {
+                Handler<Promise<Void>> handler = invocation.getArgument(0);
+                Promise<Void> promise = Promise.promise();
+                handler.handle(promise);
+                return promise.future();
+            });
+
+        var handler = OffloadHandler.of(blockingHandler);
+
+        handler.handle(routingContext);
+        verify(response, never()).setStatusCode(anyInt());
+        verify(response, never()).end(anyString());
+    }
+
+    @Test
+    void should_return_500_on_simple_blocking_handler_failure() {
+        when(vertx.<Void>executeBlocking(ArgumentMatchers.<Handler<Promise<Void>>>any()))
+            .thenReturn(Future.failedFuture(new RuntimeException("fail")));
+        var handler = OffloadHandler.of(promise -> {});
+
+        handler.handle(routingContext);
+        verify(response).setStatusCode(500);
+        verify(response).end("Internal server error");
+    }
+}

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/SafeBufferedWriterTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/SafeBufferedWriterTest.java
@@ -1,0 +1,115 @@
+package io.gravitee.node.management.http.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SafeBufferedWriterTest {
+
+    private HttpServerResponse response;
+    private SafeBufferedWriter writer;
+
+    @BeforeEach
+    void setup() {
+        response = mock(HttpServerResponse.class);
+        writer = new SafeBufferedWriter(response);
+    }
+
+    @Test
+    void should_write_when_queue_not_full() throws IOException {
+        when(response.writeQueueFull()).thenReturn(false);
+
+        writer.write("test");
+
+        verify(response).write("test");
+    }
+
+    @Test
+    void should_wait_for_drain_when_queue_full_then_write() throws Exception {
+        when(response.writeQueueFull()).thenReturn(true, false);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                Handler<Void> handler = invocation.getArgument(0);
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(100);
+                        handler.handle(null);
+                        latch.countDown();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                })
+                    .start();
+                return response;
+            })
+            .when(response)
+            .drainHandler(any());
+
+        Thread thread = new Thread(() -> {
+            try {
+                writer.write("test");
+            } catch (IOException e) {
+                fail("IOException should not have occurred: " + e.getMessage());
+            }
+        });
+        thread.start();
+
+        boolean completed = latch.await(1000, TimeUnit.MILLISECONDS);
+        thread.join(1000);
+
+        assertTrue(completed, "Drain handler was never called");
+        verify(response).write("test");
+    }
+
+    @Test
+    void should_timeout_if_drain_never_happens() {
+        when(response.writeQueueFull()).thenReturn(true);
+        when(response.drainHandler(any())).thenReturn(response);
+
+        long start = System.currentTimeMillis();
+        IOException ex = assertThrows(IOException.class, () -> writer.write("timeout"));
+        long duration = System.currentTimeMillis() - start;
+
+        assertTrue(duration >= 5000, "Should wait for the full timeout");
+        assertEquals("Timeout while waiting for write queue to drain", ex.getMessage());
+    }
+
+    @Test
+    void should_interrupt_if_thread_interrupted() {
+        when(response.writeQueueFull()).thenReturn(true);
+        when(response.drainHandler(any())).thenReturn(response);
+
+        Thread.currentThread().interrupt();
+        IOException ex = assertThrows(IOException.class, () -> writer.write("interrupted"));
+
+        assertTrue(Thread.interrupted());
+        assertTrue(ex.getMessage().contains("Interrupted while waiting for write queue"));
+    }
+
+    @Test
+    void should_support_char_array_write() throws IOException {
+        when(response.writeQueueFull()).thenReturn(false);
+
+        char[] data = "abc123".toCharArray();
+        writer.write(data, 0, 6);
+
+        verify(response).write("abc123");
+    }
+
+    @Test
+    void should_support_single_char_write() throws IOException {
+        when(response.writeQueueFull()).thenReturn(false);
+
+        writer.write('Z');
+
+        verify(response).write("Z");
+    }
+}


### PR DESCRIPTION
**Issue**


https://gravitee.atlassian.net/browse/APIM-9254

**Description**

Frequent queries to the Prometheus endpoint cause memory growth that can lead to OOM errors.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.8.2-APIM-9254-Frequent-Prometheus-endpoint-calls-cause-OOM-errors-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/6.8.2-APIM-9254-Frequent-Prometheus-endpoint-calls-cause-OOM-errors-SNAPSHOT/gravitee-node-6.8.2-APIM-9254-Frequent-Prometheus-endpoint-calls-cause-OOM-errors-SNAPSHOT.zip)
  <!-- Version placeholder end -->
