### PR TITLE
fix: properly re-evaluate cached probe

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/Result.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/Result.java
@@ -30,15 +30,18 @@ public class Result implements Serializable {
 
     private final boolean healthy;
     private final String message;
+    private final long timestamp;
 
     public Result() {
         this.healthy = true;
         this.message = null;
+        this.timestamp = System.currentTimeMillis();
     }
 
     protected Result(boolean isHealthy, String message) {
         this.healthy = isHealthy;
         this.message = message;
+        this.timestamp = System.currentTimeMillis();
     }
 
     public static Result unhealthy(Throwable error) {
@@ -75,6 +78,10 @@ public class Result implements Serializable {
 
     public String getMessage() {
         return message;
+    }
+
+    public long timestamp() {
+        return timestamp;
     }
 
     @Override

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
@@ -51,7 +51,8 @@ public class DefaultProbeEvaluator implements ProbeEvaluator {
                     .stream()
                     .filter(probe -> probeIds == null || probeIds.isEmpty() || probeIds.contains(probe.id()))
                     .map(probe -> {
-                        if (probe.isCacheable() && elapsedTime < cacheDurationMs && lastProbeResults.containsKey(probe)) {
+                        final Result lastProbeResult = lastProbeResults.get(probe);
+                        if (lastProbeResult != null && probe.isCacheable() && (now - lastProbeResult.timestamp()) < cacheDurationMs) {
                             // The probe has been evaluated once and the elapsed time is below the cache limit. Don't re-evaluate.
                             return CompletableFuture.<Void>completedFuture(null);
                         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-517

**Description**

This PR fixes an issue when evaluating a cacheable probe result. When calling /_node/health, the probes are, most of the time, not evaluated in live, but instead, a cached result is returned. The evaluation of the probes occurs every X seconds (configurable). 

Each probe result now has a timestamp to properly evaluate the elapsed time since the last time the probe was evaluated.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.8.1-archi-517-fix-probe-evaluation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.8.1-archi-517-fix-probe-evaluation-SNAPSHOT/gravitee-node-7.8.1-archi-517-fix-probe-evaluation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
