### PR TITLE
fix: properly re-evaluate cached probe

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/Result.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/healthcheck/Result.java
@@ -30,15 +30,18 @@ public class Result implements Serializable {
 
     private final boolean healthy;
     private final String message;
+    private final long timestamp;
 
     public Result() {
         this.healthy = true;
         this.message = null;
+        this.timestamp = System.currentTimeMillis();
     }
 
     protected Result(boolean isHealthy, String message) {
         this.healthy = isHealthy;
         this.message = message;
+        this.timestamp = System.currentTimeMillis();
     }
 
     public static Result unhealthy(Throwable error) {
@@ -75,6 +78,10 @@ public class Result implements Serializable {
 
     public String getMessage() {
         return message;
+    }
+
+    public long timestamp() {
+        return timestamp;
     }
 
     @Override

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/DefaultProbeEvaluator.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -26,6 +27,8 @@ public class DefaultProbeEvaluator implements ProbeEvaluator {
     private final Map<Probe, Result> lastProbeResults = new ConcurrentHashMap<>();
     private Long lastEvaluation;
 
+    private final AtomicBoolean evaluating = new AtomicBoolean(false);
+
     @Override
     public CompletableFuture<Map<Probe, Result>> evaluate() {
         return evaluate(Set.of());
@@ -41,36 +44,42 @@ public class DefaultProbeEvaluator implements ProbeEvaluator {
             return CompletableFuture.completedFuture(lastProbeResults);
         }
 
-        final List<CompletableFuture<Void>> collect =
-            this.probeManager.getProbes()
-                .stream()
-                .filter(probe -> probeIds == null || probeIds.isEmpty() || probeIds.contains(probe.id()))
-                .map(probe -> {
-                    if (probe.isCacheable()) {
-                        if (elapsedTime < cacheDurationMs && lastProbeResults.containsKey(probe)) {
+        // Make sure the previous evaluation is finished.
+        if (evaluating.compareAndSet(false, true)) {
+            final List<CompletableFuture<Void>> collect =
+                this.probeManager.getProbes()
+                    .stream()
+                    .filter(probe -> probeIds == null || probeIds.isEmpty() || probeIds.contains(probe.id()))
+                    .map(probe -> {
+                        final Result lastProbeResult = lastProbeResults.get(probe);
+                        if (lastProbeResult != null && probe.isCacheable() && (now - lastProbeResult.timestamp()) < cacheDurationMs) {
                             // The probe has been evaluated once and the elapsed time is below the cache limit. Don't re-evaluate.
                             return CompletableFuture.<Void>completedFuture(null);
                         }
+
+                        // Evaluate the probe and update the probe map.
+                        return probe
+                            .check()
+                            .exceptionally(Result::unhealthy)
+                            .thenAccept(result -> lastProbeResults.compute(probe, (probe1, result1) -> result))
+                            .toCompletableFuture();
+                    })
+                    .toList();
+
+            // Ensure all the probes have been resolved and return all the results.
+            return CompletableFuture
+                .allOf(collect.toArray(new CompletableFuture[0]))
+                .thenApply(unused -> lastProbeResults)
+                .whenComplete((probeResultMap, throwable) -> {
+                    evaluating.set(false);
+
+                    if (throwable == null) {
+                        lastEvaluation = now;
                     }
-
-                    // Evaluate the probe and update the probe map.
-                    return probe
-                        .check()
-                        .exceptionally(Result::unhealthy)
-                        .thenAccept(result -> lastProbeResults.compute(probe, (probe1, result1) -> result))
-                        .toCompletableFuture();
-                })
-                .toList();
-
-        // Ensure all the probes have been resolved and return all the results.
-        return CompletableFuture
-            .allOf(collect.toArray(new CompletableFuture[0]))
-            .thenApply(unused -> lastProbeResults)
-            .whenComplete((probeResultMap, throwable) -> {
-                if (throwable == null) {
-                    lastEvaluation = now;
-                }
-            });
+                });
+        } else {
+            return CompletableFuture.completedFuture(lastProbeResults);
+        }
     }
 
     public Map<Probe, Result> getCachedResults() {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-517

**Description**

Cherry pick of https://github.com/gravitee-io/gravitee-node/pull/427
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.10-archi-517-cherry-pick-7-0-x-fix-probe-evaluation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.0.10-archi-517-cherry-pick-7-0-x-fix-probe-evaluation-SNAPSHOT/gravitee-node-7.0.10-archi-517-cherry-pick-7-0-x-fix-probe-evaluation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
