### PR TITLE
feat: add new gcPressureProbe and expose gcPressureTooHigh from NodeH…

### DIFF
--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckService.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckService.java
@@ -34,7 +34,9 @@ import io.vertx.micrometer.backends.BackendRegistries;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -58,6 +60,10 @@ public class NodeHealthCheckService extends AbstractService {
     private MessageProducer<HealthCheck> producer;
     private ExecutorService executorService;
 
+    @Setter
+    @Getter
+    private boolean gcPressureTooHigh;
+
     @Override
     protected void doStart() throws Exception {
         if (healthConfiguration.enabled()) {
@@ -78,7 +84,8 @@ public class NodeHealthCheckService extends AbstractService {
                 probeRegistry,
                 alertEventProducer,
                 producer,
-                node
+                node,
+                this
             );
 
             managementEndpointManager.register(healthCheckEndpoint);

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/probe/GcPressureProbe.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/probe/GcPressureProbe.java
@@ -1,0 +1,162 @@
+package io.gravitee.node.monitoring.healthcheck.probe;
+
+import io.gravitee.node.api.healthcheck.Probe;
+import io.gravitee.node.api.healthcheck.Result;
+import io.gravitee.node.api.monitor.JvmInfo;
+import io.gravitee.node.monitoring.monitor.probe.JvmProbe;
+import io.gravitee.node.monitoring.spring.HealthConfiguration;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@AllArgsConstructor
+public class GcPressureProbe implements Probe {
+
+    @Autowired
+    private HealthConfiguration healthConfiguration;
+
+    private long lastTimestampInNanoseconds = 0;
+    private long lastTotalGCCollectionTime = 0;
+    private final double nbAvailableProcessors;
+
+    public GcPressureProbe() {
+        this.nbAvailableProcessors = this.getAvailableProcessors();
+    }
+
+    public GcPressureProbe(HealthConfiguration healthConfiguration) {
+        this.healthConfiguration = healthConfiguration;
+        this.nbAvailableProcessors = this.getAvailableProcessors();
+    }
+
+    @Override
+    public String id() {
+        return "gc-pressure";
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return false;
+    }
+
+    @Override
+    public boolean isVisibleByDefault() {
+        return false;
+    }
+
+    @Override
+    public CompletableFuture<Result> check() {
+        try {
+            return CompletableFuture.supplyAsync(() ->
+                getGcCpuUsage() < healthConfiguration.gcPressureThreshold()
+                    ? Result.healthy()
+                    : Result.unhealthy(
+                        String.format("GC Pressure is over the threshold of %d %%", healthConfiguration.gcPressureThreshold())
+                    )
+            );
+        } catch (Exception ex) {
+            return CompletableFuture.completedFuture(Result.unhealthy(ex));
+        }
+    }
+
+    /**
+     * Compute a GC Cpu usage metric based on elapsed time, gcCollectionTime and availableProcessors
+     * @return a percentage of cpu usage used by the GC
+     */
+    private double getGcCpuUsage() {
+        long currentTimeInNanoseconds = System.nanoTime();
+
+        // Collect all GC collection time and compute elapsedGcCollectionTime
+        long gcCollectionTime = 0;
+        for (JvmInfo.GarbageCollector collector : JvmProbe.getInstance().jvmInfo().gc.collectors) {
+            gcCollectionTime += collector.getCollectionTime();
+        }
+        long elapsedGcCollectionTime = gcCollectionTime - lastTotalGCCollectionTime;
+        lastTotalGCCollectionTime = gcCollectionTime;
+
+        //Convert gcCollectionTime in nanoseconds
+        long gcCollectionTimeInNanoseconds = TimeUnit.NANOSECONDS.convert(elapsedGcCollectionTime, TimeUnit.MILLISECONDS);
+
+        // Ignore first call
+        if (lastTimestampInNanoseconds == 0) {
+            lastTimestampInNanoseconds = currentTimeInNanoseconds;
+            return 0.0;
+        }
+        // elapsed time depends on the numbers of processor available
+        double elapsedTime = (currentTimeInNanoseconds - lastTimestampInNanoseconds) * this.nbAvailableProcessors;
+        lastTimestampInNanoseconds = currentTimeInNanoseconds;
+
+        return (gcCollectionTimeInNanoseconds / elapsedTime) * 100;
+    }
+
+    /**
+     * Method that checks if we are in a containerized environment
+     * If so base the nb of processors on cgroups value otherwise return the value of Runtime.getRuntime().availableProcessors()
+     * We need to use cgroups in containerized env since the JVM will always return at least 1
+     * and not a more fine value like 0,5 (values lower than 1 are rounded up using ceil)
+     * (see code here https://github.com/openjdk/jdk/blob/c2d76f9844aadf77a0b213a9169a7c5c8c8f1ffb/src/hotspot/os/linux/cgroupUtil_linux.cpp#L37)
+     * @return the number of available processors
+     */
+    private double getAvailableProcessors() {
+        try {
+            if (isCgroupV2()) {
+                return getCpuLimitCgroupV2();
+            }
+            return getCpuLimitCgroupV1();
+        } catch (Exception e) {
+            // Fallback to visible CPUs
+            return Runtime.getRuntime().availableProcessors();
+        }
+    }
+
+    private boolean isCgroupV2() {
+        Path cgroupPath = Paths.get("/sys/fs/cgroup");
+        return Files.exists(cgroupPath.resolve("cgroup.controllers")); // Only exists in cgroup v2
+    }
+
+    private double getCpuLimitCgroupV1() throws IOException {
+        Path quotaPath = Paths.get("/sys/fs/cgroup/cpu/cpu.cfs_quota_us");
+        Path periodPath = Paths.get("/sys/fs/cgroup/cpu/cpu.cfs_period_us");
+
+        if (Files.exists(quotaPath) && Files.exists(periodPath)) {
+            long quota = Long.parseLong(Files.readString(quotaPath).trim());
+            long period = Long.parseLong(Files.readString(periodPath).trim());
+
+            if (quota > 0 && period > 0) {
+                return (double) quota / period;
+            }
+        }
+
+        // If quota or period not found, default to availableProcessors()
+        return Runtime.getRuntime().availableProcessors();
+    }
+
+    private double getCpuLimitCgroupV2() throws IOException, NumberFormatException {
+        Path cpuMaxPath = Paths.get("/sys/fs/cgroup/cpu.max");
+        if (Files.exists(cpuMaxPath)) {
+            String content = Files.readString(cpuMaxPath).trim();
+            String[] parts = content.split(" ");
+            if (parts.length == 2 && "max".equals(parts[0])) {
+                long quota = Long.parseLong(parts[0]);
+                long period = Long.parseLong(parts[1]);
+
+                return (double) quota / period;
+            }
+        }
+
+        // Default to availableProcessors() if sthg missing
+        return Runtime.getRuntime().availableProcessors();
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/HealthConfiguration.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/HealthConfiguration.java
@@ -6,4 +6,11 @@ import java.util.concurrent.TimeUnit;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record HealthConfiguration(boolean enabled, long delay, TimeUnit unit, int cpuThreshold, int memoryThreshold) {}
+public record HealthConfiguration(
+    boolean enabled,
+    long delay,
+    TimeUnit unit,
+    int cpuThreshold,
+    int memoryThreshold,
+    int gcPressureThreshold
+) {}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/NodeMonitoringConfiguration.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/NodeMonitoringConfiguration.java
@@ -82,9 +82,10 @@ public class NodeMonitoringConfiguration {
         @Value("${services.health.delay:5000}") int delay,
         @Value("${services.health.unit:MILLISECONDS}") TimeUnit unit,
         @Value("${services.health.threshold.cpu:80}") int cpuThreshold,
-        @Value("${services.health.threshold.memory:80}") int memoryThreshold
+        @Value("${services.health.threshold.memory:80}") int memoryThreshold,
+        @Value("${services.health.threshold.gc-pressure:15}") int gcPressureThreshold
     ) {
-        return new HealthConfiguration(enabled, delay, unit, cpuThreshold, memoryThreshold);
+        return new HealthConfiguration(enabled, delay, unit, cpuThreshold, memoryThreshold, gcPressureThreshold);
     }
 
     @Bean
@@ -97,7 +98,7 @@ public class NodeMonitoringConfiguration {
     }
 
     @Bean
-    public ProbeEvaluator probeRegistry(ProbeManager probeManager, HealthConfiguration healthConfiguration) {
+    public DefaultProbeEvaluator probeRegistry(ProbeManager probeManager, HealthConfiguration healthConfiguration) {
         return new DefaultProbeEvaluator(healthConfiguration.unit().toMillis(healthConfiguration.delay()), probeManager);
     }
 

--- a/gravitee-node-monitoring/src/main/resources/META-INF/spring.factories
+++ b/gravitee-node-monitoring/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 io.gravitee.node.api.healthcheck.Probe=\
     io.gravitee.node.monitoring.healthcheck.probe.CPUProbe,\
-    io.gravitee.node.monitoring.healthcheck.probe.MemoryProbe
+    io.gravitee.node.monitoring.healthcheck.probe.MemoryProbe,\
+    io.gravitee.node.monitoring.healthcheck.probe.GcPressureProbe

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckServiceTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckServiceTest.java
@@ -53,7 +53,7 @@ class NodeHealthCheckServiceTest {
             alertEventProducer,
             node,
             Vertx.vertx(),
-            new HealthConfiguration(true, 1, MILLISECONDS, 0, 0)
+            new HealthConfiguration(true, 1, MILLISECONDS, 0, 0, 0)
         );
 
         try (MockedStatic<BackendRegistries> backendRegistries = Mockito.mockStatic(BackendRegistries.class)) {
@@ -76,7 +76,7 @@ class NodeHealthCheckServiceTest {
             alertEventProducer,
             node,
             Vertx.vertx(),
-            new HealthConfiguration(false, 1, MILLISECONDS, 0, 0)
+            new HealthConfiguration(false, 1, MILLISECONDS, 0, 0, 0)
         );
 
         cut.doStart();

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckThreadTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckThreadTest.java
@@ -45,11 +45,14 @@ class NodeHealthCheckThreadTest {
     @Mock
     private MessageProducer<HealthCheck> producer;
 
+    @Mock
+    private NodeHealthCheckService nodeHealthCheckService;
+
     private NodeHealthCheckThread cut;
 
     @BeforeEach
     void init() {
-        cut = new NodeHealthCheckThread(probeRegistry, alertEventProducer, producer, node);
+        cut = new NodeHealthCheckThread(probeRegistry, alertEventProducer, producer, node, nodeHealthCheckService);
     }
 
     @Test

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/ProbeManagerImplTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/ProbeManagerImplTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.lenient;
 
 import io.gravitee.node.api.healthcheck.Probe;
 import io.gravitee.node.monitoring.healthcheck.probe.CPUProbe;
+import io.gravitee.node.monitoring.healthcheck.probe.GcPressureProbe;
 import io.gravitee.node.monitoring.healthcheck.probe.MemoryProbe;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,9 +35,9 @@ class ProbeManagerImplTest {
     }
 
     @Test
-    void should_discover_and_register_cpu_and_memory_probes() {
-        final List<Probe> probes = cut.getProbes();
-        assertThat(probes).hasSize(2).hasOnlyElementsOfTypes(CPUProbe.class, MemoryProbe.class);
+    void should_discover_and_register_default_probes() {
+        final List<Probe> probes = cut.getProbes(); // cpu, memory and gc pressure
+        assertThat(probes).hasSize(3).hasOnlyElementsOfTypes(CPUProbe.class, MemoryProbe.class, GcPressureProbe.class);
     }
 
     @Test
@@ -49,6 +50,6 @@ class ProbeManagerImplTest {
     void should_not_register_cpu_probe_twice() {
         CPUProbe cpuProbe = new CPUProbe();
         cut.register(cpuProbe);
-        assertThat(cut.getProbes()).hasSize(2).contains(cpuProbe);
+        assertThat(cut.getProbes()).hasSize(3).contains(cpuProbe);
     }
 }

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/CPUProbeTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/CPUProbeTest.java
@@ -18,7 +18,7 @@ class CPUProbeTest {
     @Test
     @SneakyThrows
     void should_be_healthy_when_cpu_threshold_is_not_reached() {
-        final CPUProbe cpuProbe = new CPUProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, Integer.MAX_VALUE, 80));
+        final CPUProbe cpuProbe = new CPUProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, Integer.MAX_VALUE, 80, 20));
 
         final Result result = cpuProbe.check().get();
 
@@ -28,7 +28,7 @@ class CPUProbeTest {
     @Test
     @SneakyThrows
     void should_be_unhealthy_when_cpu_threshold_is_reached() {
-        final CPUProbe cpuProbe = new CPUProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, Integer.MIN_VALUE, 80));
+        final CPUProbe cpuProbe = new CPUProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, Integer.MIN_VALUE, 80, 20));
 
         final Result result = cpuProbe.check().get();
 

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/GcPressureProbeTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/GcPressureProbeTest.java
@@ -1,0 +1,40 @@
+package io.gravitee.node.monitoring.healthcheck.probe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.healthcheck.Result;
+import io.gravitee.node.monitoring.spring.HealthConfiguration;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class GcPressureProbeTest {
+
+    @Test
+    @SneakyThrows
+    void should_be_healthy_when_gc_pressure_threshold_is_not_reached() {
+        final GcPressureProbe gcPressureProbe = new GcPressureProbe(
+            new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, 80, 80, Integer.MAX_VALUE)
+        );
+
+        final Result result = gcPressureProbe.check().get();
+
+        assertThat(result.isHealthy()).isTrue();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_be_unhealthy_when_gc_pressure_threshold_is_reached() {
+        final GcPressureProbe gcPressureProbe = new GcPressureProbe(
+            new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, 80, 80, Integer.MIN_VALUE)
+        );
+
+        final Result result = gcPressureProbe.check().get();
+
+        assertThat(result.isHealthy()).isFalse();
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/MemoryProbeTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/probe/MemoryProbeTest.java
@@ -17,9 +17,9 @@ class MemoryProbeTest {
     @Test
     @SneakyThrows
     void should_be_healthy_when_memory_threshold_is_not_reached() {
-        final MemoryProbe cpuProbe = new MemoryProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, 80, Integer.MAX_VALUE));
+        final MemoryProbe memoryProbe = new MemoryProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, 80, Integer.MAX_VALUE, 20));
 
-        final Result result = cpuProbe.check().get();
+        final Result result = memoryProbe.check().get();
 
         assertThat(result.isHealthy()).isTrue();
     }
@@ -27,9 +27,9 @@ class MemoryProbeTest {
     @Test
     @SneakyThrows
     void should_be_unhealthy_when_memory_threshold_is_reached() {
-        final MemoryProbe cpuProbe = new MemoryProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, 80, Integer.MIN_VALUE));
+        final MemoryProbe memoryProbe = new MemoryProbe(new HealthConfiguration(true, 0, TimeUnit.MILLISECONDS, 80, Integer.MIN_VALUE, 20));
 
-        final Result result = cpuProbe.check().get();
+        final Result result = memoryProbe.check().get();
 
         assertThat(result.isHealthy()).isFalse();
     }


### PR DESCRIPTION
…ealthCheckService

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-493

**Description**

This PR adds a new Probe fo monitor Gc Pressure on memory. It also exposes a boolean to check if the GcPressure is too high. This information can be used by services to adapt a strategy to prevent OOM (like LogGuard in APIM).

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.9.0-feat-gc-pressure-probe-log-guard-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.9.0-feat-gc-pressure-probe-log-guard-SNAPSHOT/gravitee-node-7.9.0-feat-gc-pressure-probe-log-guard-SNAPSHOT.zip)
  <!-- Version placeholder end -->
