### PR TITLE
feat: Add rate limit policy enterprise requirement for Access Management

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -28,6 +28,7 @@ packs:
             - apim-policy-transform-avro-protobuf
             - am-policy-mfa-challenge
             - am-policy-account-linking
+            - am-policy-ratelimit
             - apim-policy-graphql-ratelimit
             - apim-policy-interops-a-idp
             - apim-policy-interops-r-idp

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -393,6 +393,7 @@ class DefaultLicenseFactoryTest {
             "am-idp-gateway-handler-saml",
             "am-policy-mfa-challenge",
             "am-policy-account-linking",
+            "am-policy-ratelimit"
             "am-resource-sfr",
             "am-resource-orange-contact-everyone",
             "am-resource-http",

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -393,7 +393,7 @@ class DefaultLicenseFactoryTest {
             "am-idp-gateway-handler-saml",
             "am-policy-mfa-challenge",
             "am-policy-account-linking",
-            "am-policy-ratelimit"
+            "am-policy-ratelimit",
             "am-resource-sfr",
             "am-resource-orange-contact-everyone",
             "am-resource-http",


### PR DESCRIPTION
**Issue**

[AM-5215](https://gravitee.atlassian.net/browse/AM-5215)

**Description**

Adds rate limit policy to enterprise requirement for Access Management

**Additional context**

Related PR which introduces Rate Limit Policy in Access Management: https://github.com/gravitee-io/gravitee-access-management/pull/6380



[AM-5215]: https://gravitee.atlassian.net/browse/AM-5215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ