### PR TITLE
fix(deps): bump protobuf-java to 3.25.5

### DIFF
--- a/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/handler/NoContentOutputErrorHandler.java
+++ b/gravitee-node-jetty/src/main/java/io/gravitee/node/jetty/handler/NoContentOutputErrorHandler.java
@@ -29,15 +29,8 @@ import org.eclipse.jetty.server.handler.ErrorHandler;
 public class NoContentOutputErrorHandler extends ErrorHandler {
 
     @Override
-    protected void writeErrorHtml(
-        Request request,
-        Writer writer,
-        Charset charset,
-        int code,
-        String message,
-        Throwable cause,
-        boolean showStacks
-    ) throws IOException {
+    protected void writeErrorHtml(Request request, Writer writer, Charset charset, int code, String message, Throwable cause)
+        throws IOException {
         // No error page
     }
 }

--- a/gravitee-node-opentelemetry/pom.xml
+++ b/gravitee-node-opentelemetry/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>vertx-grpc-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf-java.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <hazelcast.version>5.5.0</hazelcast.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
+        <protobuf-java.version>3.25.5</protobuf-java.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <opentelemetry-instrumentation.version>1.33.4-alpha</opentelemetry-instrumentation.version>
         <opentelemetry-semconv.version>1.23.1-alpha</opentelemetry-semconv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>8.2.9</gravitee-bom.version>
+        <gravitee-bom.version>8.3.41</gravitee-bom.version>
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.33.0</gravitee-reporter-api.version>


### PR DESCRIPTION
**Description**

fixes CVE-2024-7254


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.11.1-bump-protobuf-java-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.11.1-bump-protobuf-java-SNAPSHOT/gravitee-node-7.11.1-bump-protobuf-java-SNAPSHOT.zip)
  <!-- Version placeholder end -->
