### PR TITLE
fix: allow customizing client http2 windows

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
@@ -36,6 +36,11 @@ public class VertxHttpClientOptions implements Serializable {
     private static final long serialVersionUID = -7061411805967594667L;
 
     public static final int DEFAULT_HTTP2_MULTIPLEXING_LIMIT = -1;
+    public static final int DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE = -1;
+    public static final int DEFAULT_HTTP2_STREAM_WINDOW_SIZE = -1;
+    public static final int DEFAULT_MAX_FRAME_SIZE = 16384;
+    public static final int MAX_FRAME_SIZE_LOWER_BOUND = 16384;
+    public static final int MAX_FRAME_SIZE_UPPER_BOUND = 16777215;
     public static final long DEFAULT_IDLE_TIMEOUT = 60000;
     public static final long DEFAULT_KEEP_ALIVE_TIMEOUT = 30000;
     public static final long DEFAULT_CONNECT_TIMEOUT = 5000;
@@ -51,6 +56,29 @@ public class VertxHttpClientOptions implements Serializable {
 
     @Builder.Default
     private int http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
+
+    /**
+     * Connection Window Size.
+     * Setting the value to -1 means {@link io.vertx.core.http.Http2Settings#DEFAULT_INITIAL_WINDOW_SIZE} -> {@value io.vertx.core.http.Http2Settings#DEFAULT_INITIAL_WINDOW_SIZE}
+     */
+    @Builder.Default
+    private int http2ConnectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
+
+    /**
+     * Stream Window Size.
+     * Setting the value to -1 means {@link io.vertx.core.http.Http2Settings#DEFAULT_INITIAL_WINDOW_SIZE} -> {@value io.vertx.core.http.Http2Settings#DEFAULT_INITIAL_WINDOW_SIZE}
+     */
+    @Builder.Default
+    private int http2StreamWindowSize = DEFAULT_HTTP2_STREAM_WINDOW_SIZE;
+
+    /**
+     * Max frame size (initial settings).
+     * Default is the HTTP/2 spec default value: {@value DEFAULT_MAX_FRAME_SIZE}.
+     * Min value is {@value MAX_FRAME_SIZE_LOWER_BOUND}.
+     * Max value is {@value MAX_FRAME_SIZE_UPPER_BOUND}.
+     */
+    @Builder.Default
+    private int http2MaxFrameSize = DEFAULT_MAX_FRAME_SIZE;
 
     @Builder.Default
     private long idleTimeout = DEFAULT_IDLE_TIMEOUT;


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-11272

**Description**

This PR provides a way to customize Client HTTP/2 settings (connection window size, stream window size, and max frame size). At the moment, it is not possible to customize them, which can cause congestion issues when handling a large number of concurrent requests or large payloads in a single HTTP/2 connection.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.11.4-APIM-11379-Impossible-to-increase-backend-HTTP-2-window-sizes-On-Environments-4-9-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.11.4-APIM-11379-Impossible-to-increase-backend-HTTP-2-window-sizes-On-Environments-4-9-x-SNAPSHOT/gravitee-node-7.11.4-APIM-11379-Impossible-to-increase-backend-HTTP-2-window-sizes-On-Environments-4-9-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
